### PR TITLE
Add patch and get endpoint for users

### DIFF
--- a/app/api/logging/log_formatters.py
+++ b/app/api/logging/log_formatters.py
@@ -51,11 +51,17 @@ class HumanReadableFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         super(HumanReadableFormatter, self).format(record)
 
+        # In certain contexts (like during a request) we want to
+        # attach additional information (like a request ID) to all
+        # log messages for tracking purposes. Add that here.
+        additional_log_context = get_logging_context_attributes()
+        extra = record.__dict__ | additional_log_context
+
         return decodelog.format_line(
             datetime.utcfromtimestamp(record.created),
             record.name,
             record.funcName,
             record.levelname,
             record.message,
-            record.__dict__,
+            extra,
         )

--- a/app/api/route/handler/user_handler.py
+++ b/app/api/route/handler/user_handler.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 from uuid import uuid4
 
@@ -8,13 +8,14 @@ import api.logging
 from api.db.models.user_models import RoleEnum, User, UserRole
 from api.route.api_context import ApiContext
 from api.route.request import BaseRequestModel
+from api.route.route_utils import get_or_404
 
 logger = api.logging.get_logger(__name__)
 
 
 class RoleParams(BaseRequestModel):
     role_description: RoleEnum
-    created_at: Optional[date]
+    created_at: Optional[datetime]
 
 
 class UserParams(BaseRequestModel):
@@ -25,6 +26,16 @@ class UserParams(BaseRequestModel):
     phone_number: str
     date_of_birth: date
     is_active: bool
+    roles: Optional[list[RoleParams]]
+
+
+class UserPatchParams(BaseRequestModel):
+    first_name: Optional[str]
+    middle_name: Optional[str]
+    last_name: Optional[str]
+    phone_number: Optional[str]
+    date_of_birth: Optional[date]
+    is_active: Optional[bool]
     roles: Optional[list[RoleParams]]
 
 
@@ -59,4 +70,73 @@ def create_user(api_context: ApiContext) -> UserResponse:
 
 
 def patch_user(user_id: str, api_context: ApiContext) -> UserResponse:
-    pass
+    user = get_or_404(api_context.db_session, User, user_id)
+
+    request = UserPatchParams.parse_obj(api_context.request_body)
+    for key, value in request.get_set_params():
+
+        if key == "roles":
+            handle_role_patch(user, value, api_context)
+            continue
+
+        setattr(user, key, value)
+
+    # Flush the changes to the DB and then
+    # refresh to get the roles updated on
+    # the user object that may have been changed
+    api_context.db_session.flush()
+    api_context.db_session.refresh(user)
+
+    return UserResponse.from_orm(user)
+
+
+def get_user(user_id: str, api_context: ApiContext) -> UserResponse:
+    user = get_or_404(api_context.db_session, User, user_id)
+
+    return UserResponse.from_orm(user)
+
+
+def handle_role_patch(
+    user: User, request_roles: Optional[list[RoleParams]], api_context: ApiContext
+) -> None:
+    # Because roles are a list, we need to handle them slightly different.
+    # There are two scenarios possible:
+    # 1. The roles match -> do nothing
+    # 2. The roles don't match -> add/remove from the DB roles to make them match
+    #
+    # Matching is based purely off the role description at the moment
+    # In a more thorough system, it might make sense to make a patch endpoint
+    # that explicitly adds or removes a single role for a user at a time.
+
+    # Shouldn't be called if None, but makes mypy happy
+    if request_roles is None:
+        return
+
+    # We'll work with just the role description strings to avoid
+    # comparing nested objects and values. As roles are unique in the
+    # DB per user, any deduplicating this does is fine.
+    if user.roles is not None:
+        current_role_descriptions = set([role.role_description for role in user.roles])
+    else:
+        current_role_descriptions = set()
+
+    request_role_descriptions = set([role.role_description for role in request_roles])
+
+    # If they match, do nothing
+    if set(current_role_descriptions) == set(request_role_descriptions):
+        return
+
+    # Figure out which roles need to be deleted and added
+    roles_to_delete = current_role_descriptions - request_role_descriptions
+    roles_to_add = request_role_descriptions - current_role_descriptions  # type:ignore
+
+    # Go through existing roles and delete the ones that are no longer needed
+    if user.roles:
+        for current_user_role in user.roles:
+            if current_user_role.role_description in roles_to_delete:
+                api_context.db_session.delete(current_user_role)
+
+    # Add any new roles
+    for role_description in roles_to_add:
+        user_role = UserRole(user_id=user.user_id, role_description=role_description)
+        api_context.db_session.add(user_role)

--- a/app/api/route/request.py
+++ b/app/api/route/request.py
@@ -1,6 +1,27 @@
+from typing import Any, Iterable
+
 from pydantic import BaseModel
 
 
 class BaseRequestModel(BaseModel):
     class Config:
         orm_mode = True
+
+    def get_set_params(self) -> Iterable[tuple[str, Any]]:
+        """
+        Utility method for fetching just the parameters that were
+        set when creating the pydantic model. This can be used as
+
+        ```
+        for key, value in model.get_set_params():
+            ...
+        ```
+
+        and is functionally equivalent to:
+        ```
+        for key in model.__fields_set__:
+            value = getattr(model, key)
+        ```
+        """
+        for k in self.__fields_set__:
+            yield k, getattr(self, k)

--- a/app/api/route/route_utils.py
+++ b/app/api/route/route_utils.py
@@ -1,0 +1,21 @@
+from typing import Type, TypeVar
+from uuid import UUID
+
+from sqlalchemy.orm import scoped_session
+from werkzeug.exceptions import NotFound
+
+_T = TypeVar("_T")
+
+
+def get_or_404(db_session: scoped_session, model: Type[_T], id: UUID | str | int) -> _T:
+    """
+    Utility method for fetching a single record from the DB by
+    its primary key ID, and raising a NotFound exception if
+    no such record exists.
+    """
+    result = db_session.query(model).get(id)
+
+    if result is None:
+        raise NotFound(description=f"Could not find {model.__name__} with ID {id}")
+
+    return result

--- a/app/api/route/user_route.py
+++ b/app/api/route/user_route.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import flask
 
 import api.logging as logging
@@ -21,7 +23,7 @@ def user_post() -> flask.Response:
 
         logger.info(
             "Successfully inserted user",
-            extra={"user_id": response.user_id},
+            extra=get_user_log_params(response),
         )
         return response_util.success_response(
             message="Success", data=response.dict(), status_code=201
@@ -30,13 +32,43 @@ def user_post() -> flask.Response:
 
 # Update user
 def user_patch(user_id: str) -> flask.Response:
-    return response_util.success_response(
-        message="Success", data={}, status_code=200
-    ).to_api_response()
+    """
+    PATCH /v1/user/:user_id
+    """
+    logger.info("PATCH /v1/user/:user_id")
+
+    with api_context_manager() as api_context:
+        response = user_handler.patch_user(user_id, api_context)
+
+        logger.info(
+            "Successfully patched user",
+            extra=get_user_log_params(response),
+        )
+
+        return response_util.success_response(
+            message="Success", data=response.dict(), status_code=200
+        ).to_api_response()
 
 
 # Get user
 def user_get(user_id: str) -> flask.Response:
-    return response_util.success_response(
-        message="Success", data={}, status_code=200
-    ).to_api_response()
+    """
+    GET /v1/user/:user_id
+    """
+    logger.info("GET /v1/user/:user_id")
+
+    with api_context_manager() as api_context:
+        response = user_handler.get_user(user_id, api_context)
+
+        logger.info(
+            "Successfully fetched user",
+            extra=get_user_log_params(response),
+        )
+
+        return response_util.success_response(
+            message="Success", data=response.dict(), status_code=200
+        ).to_api_response()
+
+
+def get_user_log_params(user_response: user_handler.UserResponse) -> dict[str, Any]:
+    return {"user_id": user_response.user_id}

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -38,14 +38,72 @@ paths:
               schema:
                 type: boolean
 
+  /user/{user_id}:
+    get:
+      tags:
+        - User
+      summary: Get endpoint for a user in the DB
+      operationId: api.route.user_route.user_get
+      parameters:
+        - name: user_id
+          in: path
+          schema:
+            type: string
+            format: uuid
+          description: ID of User to get
+          required: true
+      responses:
+        "200":
+          description: A successful response returns a 200 status code and the user object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - User
+      summary: Get endpoint for a user in the DB
+      operationId: api.route.user_route.user_patch
+      parameters:
+        - name: user_id
+          in: path
+          schema:
+            type: string
+            format: uuid
+          description: ID of User to get
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserBase"
+      responses:
+        "200":
+          description: A successful response returns a 200 status code and the user object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /user:
     post:
-      security:
-        - api_key: []
       tags:
         - User
       summary: Example post endpoint for creating a simple user in the DB
       operationId: api.route.user_route.user_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserBase"
       responses:
         "201":
           description: User was successfully submitted
@@ -63,11 +121,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserBase"
+
 
 
 components:
@@ -77,6 +131,7 @@ components:
       name: X-Auth
       in: header
       x-apikeyInfoFunc: api.auth.api_key_auth.api_key_auth
+
   schemas:
     Date:
       type: string
@@ -135,10 +190,6 @@ components:
           - User
           - Admin
           - Third Party
-        created_at:
-          type: string
-          format: date-time
-          nullable: true
 
     SuccessfulResponse:
       type: object
@@ -213,6 +264,16 @@ components:
           type: string
       additionalProperties: false
 
-
-
-
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    BadRequest:
+      description: There was a problem with your request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -66,7 +66,7 @@ paths:
     patch:
       tags:
         - User
-      summary: Get endpoint for a user in the DB
+      summary: Update a user in the DB
       operationId: api.route.user_route.user_patch
       parameters:
         - name: user_id


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-application-flask/issues/4

## Changes
This PR adds a GET and PATCH endpoint for the user model to the template repo. This follows up work that added a POST endpoint and related components.

## Context for reviewers
GET endpoint is pretty routine, give an ID, get the model.

PATCH is mostly routine, although the conventions there are slightly less defined. Any unset fields aren't modified, only the set fields. The primary complexity was adjusting roles. It might make more sense to have these as their own separate dedicated endpoint (something like `user-add-role` and `user-remove-role`) if this is deemed too complex. It basically does a set-diff to see what needs to be added/removed to get to the desired state.

Are there any other common-ish endpoint types you would like to see added?

## Testing
Create a user via the POST endpoint:
<img width="418" alt="Screen Shot 2022-09-22 at 4 54 13 PM" src="https://user-images.githubusercontent.com/46358556/191849283-6ac4762c-ed57-4933-8b8f-25666afa6e16.png">

You can GET them:
<img width="567" alt="Screen Shot 2022-09-22 at 4 54 40 PM" src="https://user-images.githubusercontent.com/46358556/191849316-eff98578-ff06-4ded-8b99-d5a0409cdff4.png">

PATCH request:
<img width="302" alt="Screen Shot 2022-09-22 at 4 55 08 PM" src="https://user-images.githubusercontent.com/46358556/191849365-0fba1670-2f8a-4572-9c0e-060ffe6a3278.png">

PATCH response:
<img width="447" alt="Screen Shot 2022-09-22 at 4 55 17 PM" src="https://user-images.githubusercontent.com/46358556/191849389-e7613d2a-4f1c-411d-82fb-48b870831310.png">

GET again after the PATCH:
<img width="611" alt="Screen Shot 2022-09-22 at 4 56 46 PM" src="https://user-images.githubusercontent.com/46358556/191849576-80713f73-2b57-4a73-92ee-9f2860ea916c.png">

