### PR TITLE
Add release build target

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official python3 image based on Debian 11 "Bullseye".
 # https://hub.docker.com/_/python
-FROM python:3-slim
+FROM python:3-slim AS release
 # Keep container packages up-to-date.
 RUN apt update \
     && apt upgrade --yes

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,9 @@
 # Use the official python3 image based on Debian 11 "Bullseye".
 # https://hub.docker.com/_/python
+
+# The build stage that will be used to deploy to the various environments
+# needs to be called `release` in order to integrate with the repo's
+# top-level Makefile
 FROM python:3-slim AS release
 # Keep container packages up-to-date.
 RUN apt update \


### PR DESCRIPTION
## Ticket

n/a

## Changes
- Add `release` build target to Dockerfile

## Context for reviewers
In this [PR template-infra#116](https://github.com/navapbc/template-infra/pull/116) we established an interface such that every application's Dockerfile should have a named build stage called `release`, so that `make release-build` from the template-infra `Makefile` can integrate properly with the application's Dockerfile.

## Testing
Didn't test, since I just added a name to the build stage but didn't change anything else
