### PR TITLE
Update README to correctly point to the getting-started doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ cp -r \
 rm -fr template-application-flask
 ```
 
-Now you're ready to [get started](./getting-started.md).
+Now you're ready to [get started](./docs/app/getting-started.md).


### PR DESCRIPTION
## Ticket

N/A

## Changes
* Fixes the `getting-started` link on the README

## Context for reviewers
N/A

## Testing
N/A

