### PR TITLE
Make ordering of fields in generated openapi spec deterministic

### DIFF
--- a/app/api/route/healthcheck.py
+++ b/app/api/route/healthcheck.py
@@ -1,6 +1,5 @@
 from typing import Tuple
 
-import marshmallow
 from apiflask import APIBlueprint
 from sqlalchemy import text
 from werkzeug.exceptions import ServiceUnavailable
@@ -8,11 +7,12 @@ from werkzeug.exceptions import ServiceUnavailable
 import api.logging
 from api.route import response
 from api.route.api_context import api_context_manager
+from api.route.schemas import request_schema
 
 logger = api.logging.get_logger(__name__)
 
 
-class HealthcheckSchema(marshmallow.Schema):
+class HealthcheckSchema(request_schema.OrderedSchema):
     message: str
 
 

--- a/app/api/route/schemas/request_schema.py
+++ b/app/api/route/schemas/request_schema.py
@@ -4,7 +4,7 @@ import apiflask
 # Use ordered schemas to ensure that the order of fields in the generated OpenAPI
 # schema is deterministic.
 # This should no longer be needed once apiflask is updated to use ordered schemas
-# TODO update apiflask with fix to default to ordered schemas
+# TODO(https://github.com/navapbc/template-application-flask/issues/59) update apiflask with fix to default to ordered schemas
 # See https://github.com/apiflask/apiflask/issues/385#issuecomment-1364463104
 class OrderedSchema(apiflask.Schema):
     class Meta:

--- a/app/api/route/schemas/request_schema.py
+++ b/app/api/route/schemas/request_schema.py
@@ -1,0 +1,25 @@
+import dataclasses
+
+import apiflask
+
+
+@dataclasses.dataclass
+class RequestModel:
+    """Base class for request models.
+
+    Request models are used to define input schemas for
+    API endpoints. They are used to store the request body after deserializing
+    the request body.
+    """
+
+    pass
+
+
+# Use ordered schemas to ensure that the order of fields in the generated OpenAPI
+# schema is deterministic.
+# This should no longer be needed once apiflask is updated to use ordered schemas
+# TODO update apiflask with fix to default to ordered schemas
+# See https://github.com/apiflask/apiflask/issues/385#issuecomment-1364463104
+class OrderedSchema(apiflask.Schema):
+    class Meta:
+        ordered = True

--- a/app/api/route/schemas/request_schema.py
+++ b/app/api/route/schemas/request_schema.py
@@ -1,18 +1,4 @@
-import dataclasses
-
 import apiflask
-
-
-@dataclasses.dataclass
-class RequestModel:
-    """Base class for request models.
-
-    Request models are used to define input schemas for
-    API endpoints. They are used to store the request body after deserializing
-    the request body.
-    """
-
-    pass
 
 
 # Use ordered schemas to ensure that the order of fields in the generated OpenAPI

--- a/app/api/route/schemas/response_schema.py
+++ b/app/api/route/schemas/response_schema.py
@@ -1,8 +1,10 @@
 import marshmallow
 from apiflask import fields
 
+from api.route.schemas import request_schema
 
-class ValidationErrorSchema(marshmallow.Schema):
+
+class ValidationErrorSchema(request_schema.OrderedSchema):
     type = fields.String(description="The type of error")
     message = fields.String(description="The message to return")
     rule = fields.String(description="The rule that failed")
@@ -10,7 +12,7 @@ class ValidationErrorSchema(marshmallow.Schema):
     value = fields.String(description="The value that failed")
 
 
-class ResponseSchema(marshmallow.Schema):
+class ResponseSchema(request_schema.OrderedSchema):
     message = fields.String(description="The message to return")
     data = fields.Field(description="The REST resource object", dump_default={})
     status_code = fields.Integer(description="The HTTP status code", dump_default=200)

--- a/app/api/route/schemas/response_schema.py
+++ b/app/api/route/schemas/response_schema.py
@@ -1,4 +1,3 @@
-import marshmallow
 from apiflask import fields
 
 from api.route.schemas import request_schema

--- a/app/api/route/schemas/user_schemas.py
+++ b/app/api/route/schemas/user_schemas.py
@@ -5,13 +5,14 @@ from apiflask import fields
 from marshmallow import fields as marshmallow_fields
 
 from api.db.models.user_models import Role, RoleType
+from api.route.schemas import request_schema
 
 ##############
 # Role Models
 ##############
 
 
-class RoleSchema(marshmallow.Schema):
+class RoleSchema(request_schema.OrderedSchema):
     type = marshmallow_fields.Enum(RoleType, description="The name of the role", by_value=True)
 
     # Output only fields
@@ -28,7 +29,7 @@ class RoleSchema(marshmallow.Schema):
 ##############
 
 
-class UserSchema(marshmallow.Schema):
+class UserSchema(request_schema.OrderedSchema):
     id = fields.UUID(dump_only=True)
     first_name = fields.String(description="The user's first name", required=True)
     middle_name = fields.String(description="The user's middle name")

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -23,20 +23,26 @@ paths:
                   message:
                     type: string
                     description: The message to return
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-                  warnings:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
                   data:
                     $ref: '#/components/schemas/Healthcheck'
                   status_code:
                     type: integer
                     description: The HTTP status code
+                  warnings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
           description: Successful response
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+          description: Service Unavailable
       tags:
       - Health
       summary: Health
@@ -53,19 +59,19 @@ paths:
                   message:
                     type: string
                     description: The message to return
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-                  warnings:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
                   data:
                     $ref: '#/components/schemas/User'
                   status_code:
                     type: integer
                     description: The HTTP status code
+                  warnings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
           description: Successful response
         '400':
           content:
@@ -107,19 +113,19 @@ paths:
                   message:
                     type: string
                     description: The message to return
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-                  warnings:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
                   data:
                     $ref: '#/components/schemas/User'
                   status_code:
                     type: integer
                     description: The HTTP status code
+                  warnings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
           description: Successful response
         '401':
           content:
@@ -155,19 +161,19 @@ paths:
                   message:
                     type: string
                     description: The message to return
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-                  warnings:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
                   data:
                     $ref: '#/components/schemas/User'
                   status_code:
                     type: integer
                     description: The HTTP status code
+                  warnings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
           description: Successful response
         '400':
           content:
@@ -203,21 +209,21 @@ components:
     ValidationError:
       type: object
       properties:
+        type:
+          type: string
+          description: The type of error
         message:
           type: string
           description: The message to return
         rule:
           type: string
           description: The rule that failed
-        type:
-          type: string
-          description: The type of error
-        value:
-          type: string
-          description: The value that failed
         field:
           type: string
           description: The field that failed
+        value:
+          type: string
+          description: The value that failed
     HTTPError:
       properties:
         detail:
@@ -231,19 +237,32 @@ components:
     Role:
       type: object
       properties:
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
         type:
           description: The name of the role
         created_at:
           type: string
           format: date-time
           readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
     User:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        first_name:
+          type: string
+          description: The user's first name
+        middle_name:
+          type: string
+          description: The user's middle name
+        last_name:
+          type: string
+          description: The user's last name
         phone_number:
           type: string
           description: The user's phone number
@@ -253,33 +272,20 @@ components:
           type: string
           format: date
           description: The users date of birth
-        created_at:
-          type: string
-          format: date-time
-          readOnly: true
-        middle_name:
-          type: string
-          description: The user's middle name
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-        last_name:
-          type: string
-          description: The user's last name
+        is_active:
+          type: boolean
+          description: Whether the user is active
         roles:
           type: array
           items:
             $ref: '#/components/schemas/Role'
-        first_name:
+        created_at:
           type: string
-          description: The user's first name
-        is_active:
-          type: boolean
-          description: Whether the user is active
-        user_id:
+          format: date-time
+          readOnly: true
+        updated_at:
           type: string
-          format: uuid
+          format: date-time
           readOnly: true
       required:
       - date_of_birth
@@ -291,6 +297,19 @@ components:
     UserUpdate:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        first_name:
+          type: string
+          description: The user's first name
+        middle_name:
+          type: string
+          description: The user's middle name
+        last_name:
+          type: string
+          description: The user's last name
         phone_number:
           type: string
           description: The user's phone number
@@ -300,33 +319,20 @@ components:
           type: string
           format: date
           description: The users date of birth
-        created_at:
-          type: string
-          format: date-time
-          readOnly: true
-        middle_name:
-          type: string
-          description: The user's middle name
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-        last_name:
-          type: string
-          description: The user's last name
+        is_active:
+          type: boolean
+          description: Whether the user is active
         roles:
           type: array
           items:
             $ref: '#/components/schemas/Role'
-        first_name:
+        created_at:
           type: string
-          description: The user's first name
-        is_active:
-          type: boolean
-          description: Whether the user is active
-        user_id:
+          format: date-time
+          readOnly: true
+        updated_at:
           type: string
-          format: uuid
+          format: date-time
           readOnly: true
   securitySchemes:
     ApiKeyAuth:


### PR DESCRIPTION
## Ticket

Resolves #58

## Changes
see title

## Context for reviewers
Generated schema fields in openapi spec was non-deterministic. I created a ticket in apiflask for this issue: https://github.com/apiflask/apiflask/issues/385 which has been resolved, once a new version of apiflask has been published we should be able to update apiflask and then remove this workaround. I created #59 to keep track of that TODO.

## Testing
