### PR TITLE
Fix marshmallow deprecation warnings

### DIFF
--- a/app/api/route/schemas/response_schema.py
+++ b/app/api/route/schemas/response_schema.py
@@ -4,16 +4,16 @@ from api.route.schemas import request_schema
 
 
 class ValidationErrorSchema(request_schema.OrderedSchema):
-    type = fields.String(description="The type of error")
-    message = fields.String(description="The message to return")
-    rule = fields.String(description="The rule that failed")
-    field = fields.String(description="The field that failed")
-    value = fields.String(description="The value that failed")
+    type = fields.String(metadata={"description": "The type of error"})
+    message = fields.String(metadata={"description": "The message to return"})
+    rule = fields.String(metadata={"description": "The rule that failed"})
+    field = fields.String(metadata={"description": "The field that failed"})
+    value = fields.String(metadata={"description": "The value that failed"})
 
 
 class ResponseSchema(request_schema.OrderedSchema):
-    message = fields.String(description="The message to return")
-    data = fields.Field(description="The REST resource object", dump_default={})
-    status_code = fields.Integer(description="The HTTP status code", dump_default=200)
+    message = fields.String(metadata={"description": "The message to return"})
+    data = fields.Field(metadata={"description": "The REST resource object"}, dump_default={})
+    status_code = fields.Integer(metadata={"description": "The HTTP status code"}, dump_default=200)
     warnings = fields.List(fields.Nested(ValidationErrorSchema), dump_default=[])
     errors = fields.List(fields.Nested(ValidationErrorSchema), dump_default=[])

--- a/app/api/route/schemas/user_schemas.py
+++ b/app/api/route/schemas/user_schemas.py
@@ -11,7 +11,9 @@ from api.route.schemas import request_schema
 
 class RoleSchema(request_schema.OrderedSchema):
     type = marshmallow_fields.Enum(
-        user_models.RoleType, description="The name of the role", by_value=True
+        user_models.RoleType,
+        by_value=True,
+        metadata={"description": "The name of the role"},
     )
 
     # Output only fields
@@ -29,21 +31,23 @@ class RoleSchema(request_schema.OrderedSchema):
 
 class UserSchema(request_schema.OrderedSchema):
     id = fields.UUID(dump_only=True)
-    first_name = fields.String(description="The user's first name", required=True)
-    middle_name = fields.String(description="The user's middle name")
-    last_name = fields.String(description="The user's last name", required=True)
+    first_name = fields.String(metadata={"description": "The user's first name"}, required=True)
+    middle_name = fields.String(metadata={"description": "The user's middle name"})
+    last_name = fields.String(metadata={"description": "The user's last name"}, required=True)
     phone_number = fields.String(
-        description="The user's phone number",
-        example="123-456-7890",
         required=True,
-        pattern=r"^([0-9]|\*){3}\-([0-9]|\*){3}\-[0-9]{4}$",
+        metadata={
+            "description": "The user's phone number",
+            "example": "123-456-7890",
+            "pattern": r"^([0-9]|\*){3}\-([0-9]|\*){3}\-[0-9]{4}$",
+        },
     )
     date_of_birth = fields.Date(
-        description="The users date of birth",
+        metadata={"description": "The users date of birth"},
         required=True,
     )
     is_active = fields.Boolean(
-        description="Whether the user is active",
+        metadata={"description": "Whether the user is active"},
         required=True,
     )
     roles = fields.List(fields.Nested(RoleSchema), required=True)


### PR DESCRIPTION
## Ticket

Resolves #66

## Changes
> What was added, updated, or removed in this PR.

## Context for reviewers
In PR #65 , @chouinar pointed out that there were a bunch of marshmallow warnings when running pytest, probably introduced during #51 . This PR fixes the marshmallow warnings.

I still see other warnings from site-packages, not sure how to fix those. Any ideas?
```
================================================================================================ warnings summary =================================================================================================
../root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/botocore/utils.py:15
  /root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/botocore/utils.py:15: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

../root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/apispec/utils.py:104
  /root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/apispec/utils.py:104: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    MIN_INCLUSIVE_VERSION = version.LooseVersion("2.0")

../root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/apispec/utils.py:105
  /root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/apispec/utils.py:105: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    MAX_EXCLUSIVE_VERSION = version.LooseVersion("4.0")

../root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/certifi/core.py:36
  /root/.cache/pypoetry/virtualenvs/template-application-flask-o9msT97p-py3.11/lib/python3.11/site-packages/certifi/core.py:36: DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    _CACERT_CTX = get_path("certifi", "cacert.pem")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

## Testing
`make test`

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/447859/211114663-a4cc6234-91e4-4221-a06b-40996b969c15.png">
