### PR TITLE
Fix ability to access server when running in container

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -26,6 +26,10 @@ RUN poetry install --no-root
 # Copy application files.
 COPY . /srv
 
+# Set the host to 0.0.0.0 to make the server available external
+# to the Docker container that it's running in.
+ENV HOST=0.0.0.0
+
 # Install application dependencies.
 # https://python-poetry.org/docs/basic-usage/#installing-dependencies
 RUN poetry install

--- a/app/Makefile
+++ b/app/Makefile
@@ -175,6 +175,9 @@ create-user-csv:
 # Miscellaneous Utilities
 ##################################################
 
+login: start ## Start shell in running container
+	docker exec -it $(APP_NAME) bash
+
 # Pauses for 5 seconds
 sleep-5:
 	sleep 5

--- a/app/api/__main__.py
+++ b/app/api/__main__.py
@@ -23,6 +23,9 @@ def main() -> None:
 
     app = api.app.create_app()
     environment = app_config.environment
+
+    # When running in a container, the host needs to be set to 0.0.0.0 so that the app can be
+    # accessed from outside the container. See Dockerfile
     host = app_config.host
     port = app_config.port
 

--- a/app/api/__main__.py
+++ b/app/api/__main__.py
@@ -20,18 +20,23 @@ def main() -> None:
 
     api.logging.audit.init_security_logging()
     api.logging.init(__package__)
-    logger.info("Running API Application")
 
     app = api.app.create_app()
+    environment = app_config.environment
+    host = app_config.host
     port = app_config.port
+
+    logger.info(
+        "Running API Application", extra={"environment": environment, "host": host, "port": port}
+    )
 
     if app_config.environment == "local":
         # If python files are changed, the app will auto-reload
         # Note this doesn't have the OpenAPI yaml file configured at the moment
-        app.run(port=port, use_reloader=True, reloader_type="stat")
+        app.run(host=host, port=port, use_reloader=True, reloader_type="stat")
     else:
         # Don't enable the reloader if non-local
-        app.run(port=port)
+        app.run(host=host, port=port)
 
 
 main()

--- a/app/api/app_config.py
+++ b/app/api/app_config.py
@@ -3,4 +3,9 @@ from api.util.env_config import PydanticBaseEnvConfig
 
 class AppConfig(PydanticBaseEnvConfig):
     environment: str
+
+    # Set the host to 0.0.0.0 to make the server available external
+    # to the Docker container that it's running in.
+    # See https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.run
+    host: str = "0.0.0.0"
     port: int = 8080

--- a/app/api/app_config.py
+++ b/app/api/app_config.py
@@ -4,8 +4,10 @@ from api.util.env_config import PydanticBaseEnvConfig
 class AppConfig(PydanticBaseEnvConfig):
     environment: str
 
-    # Set the host to 0.0.0.0 to make the server available external
-    # to the Docker container that it's running in.
+    # Set HOST to 127.0.0.1 by default to avoid other machines on the network
+    # from accessing the application. This is especially important if you are
+    # running the application locally on a public network. This needs to be
+    # overriden to 0.0.0.0 when running in a container
     # See https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.run
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8080

--- a/app/local.env
+++ b/app/local.env
@@ -3,6 +3,13 @@
 # by calling load_local_env_vars() from app/api/util/local.py
 
 ENVIRONMENT=local
+# Set HOST to 127.0.0.1 by default when running locally to avoid
+# other machines on the network from accessing the application.
+# This is especially important if you are running the application
+# on a public network.
+# This needs to be override to 0.0.0.0 when running in a container
+# (see docker-compose.yml)
+HOST=127.0.0.1
 PORT=8080
 
 # Python path needs to be specified

--- a/app/local.env
+++ b/app/local.env
@@ -3,13 +3,6 @@
 # by calling load_local_env_vars() from app/api/util/local.py
 
 ENVIRONMENT=local
-# Set HOST to 127.0.0.1 by default when running locally to avoid
-# other machines on the network from accessing the application.
-# This is especially important if you are running the application
-# on a public network.
-# This needs to be override to 0.0.0.0 when running in a container
-# (see docker-compose.yml)
-HOST=127.0.0.1
 PORT=8080
 
 # Python path needs to be specified

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,12 +31,6 @@ services:
     env_file: ./app/local.env
     # NOTE: These values take precedence if the same value is specified in the env_file.
     environment:
-      # When running in the container, set the host to 0.0.0.0 so that the app can be
-      # accessed from outside the container. This needs to be set to override the
-      # setting in local.env
-      # (see app_config.py)
-      - HOST=0.0.0.0
-
       # The env_file defines DB_HOST=localhost for accessing a non-dockerized database. 
       # In the docker-compose, we tell the app to use the dockerized database service 
       - DB_HOST=main-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   main-db:
     image: postgres:14-alpine # Docs for options to the postgres server command:
     # https://www.postgresql.org/docs/current/app-postgres.html
+
+    container_name: main-db
+
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     # Load environment variables for local development. 
     env_file: ./app/local.env
@@ -21,6 +24,8 @@ services:
     # not on an image repository.
     build: ./app
     # Expose the application port for local development.
+
+    container_name: main-app
 
     # Load environment variables for local development
     env_file: ./app/local.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
     env_file: ./app/local.env
     # NOTE: These values take precedence if the same value is specified in the env_file.
     environment:
+      # When running in the container, set the host to 0.0.0.0 so that the app can be
+      # accessed from outside the container. This needs to be set to override the
+      # setting in local.env
+      # (see app_config.py)
+      - HOST=0.0.0.0
+
       # The env_file defines DB_HOST=localhost for accessing a non-dockerized database. 
       # In the docker-compose, we tell the app to use the dockerized database service 
       - DB_HOST=main-db


### PR DESCRIPTION
## Ticket

Resolves #70

## Changes
* Add container name when running from docker-compose
* Add make login to log into docker container
* Add AppConfig.host to set host that Flask app listens to, defaulting to 127.0.0.1, the secure default for Flask
* Override HOST in Dockerfile to 0.0.0.0 to allow external connections when running in a container

## Context for reviewers
Since PR #51 was merged, the app was broken when running in docker. This was because connexion when running the app in __main__.py, connexion defaults host to 0.0.0.0, but flask defaults host to 127.0.0.1, so the app within the container wasn't allowing incoming requests external to the container.

## Testing
* Tested with `make start` which runs docker-compose up, saw from logs that host is 0.0.0.0 and hit localhost:8080/health in a browser
* Tested with `poetry run python -m api` which runs locally, saw from logs that host is 127.0.0.1 and hit localhost:8080/health in a browser to see that it works
