### PR TITLE
Ignore os.walk event in security audit logs

### DIFF
--- a/app/api/logging/audit.py
+++ b/app/api/logging/audit.py
@@ -35,6 +35,7 @@ IGNORE_AUDIT_EVENTS = {
     "object.__setattr__",
     "os.listdir",
     "os.scandir",
+    "os.walk",
     "socket.__new__",
     "sys._current_frames",
     "sys._getframe",


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
os.walk is pretty noisy, maybe we should silence it

## Testing
CI