### PR TITLE
Don't kill all processes when testing os.kill

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -161,7 +161,7 @@ lint-poetry-version: ## Check poetry version
 	grep --quiet 'lock-version = "1.1"' poetry.lock
 
 lint-security: # https://bandit.readthedocs.io/en/latest/index.html
-	$(PY_RUN_CMD) bandit -r . --number 3 --skip B101 -ll -x ./.venv
+	$(PY_RUN_CMD) bandit -c pyproject.toml -r . --number 3 --skip B101 -ll -x ./.venv
 
 
 ##################################################

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -83,6 +83,10 @@ warn_unused_ignores = true
 
 plugins = ["sqlalchemy.ext.mypy.plugin"]
 
+[tool.bandit]
+# Ignore audit logging test file since test audit logging requires a lot of operations that trigger bandit warnings
+exclude_dirs = ["./tests/api/logging/test_audit.py"]
+
 [[tool.mypy.overrides]]
 # Migrations are generated without "-> None"
 # for the returns. Rather than require manually
@@ -102,3 +106,4 @@ filterwarnings = [
 
 [tool.coverage.run]
 omit = ["api/db/migrations/*.py"]
+

--- a/app/tests/api/logging/test_audit.py
+++ b/app/tests/api/logging/test_audit.py
@@ -144,7 +144,7 @@ def test_audit_hook(
 
 def test_os_kill(init_audit_hook, caplog: pytest.LogCaptureFixture):
     # Start a process to kill
-    process = subprocess.Popen("ls")
+    process = subprocess.Popen("cat")
     os.kill(process.pid, signal.SIGTERM)
 
     expected_records = [

--- a/app/tests/api/logging/test_audit.py
+++ b/app/tests/api/logging/test_audit.py
@@ -41,18 +41,6 @@ test_audit_hook_data = [
         id="open",
     ),
     pytest.param(
-        os.kill,
-        (-1, signal.SIGTERM),  # Using PID=-1 since it should not ever be a valid PID
-        [
-            {
-                "msg": "os.kill",
-                "audit.args.pid": -1,
-                "audit.args.sig": signal.SIGTERM,
-            }
-        ],
-        id="os.kill",
-    ),
-    pytest.param(
         os.rename,
         ("/tmp/oldname", "/tmp/newname"),
         [
@@ -154,10 +142,28 @@ def test_audit_hook(
         assert_record_match(record, expected_record)
 
 
+def test_os_kill(init_audit_hook, caplog: pytest.LogCaptureFixture):
+    # Start a process to kill
+    process = subprocess.Popen("ls")
+    os.kill(process.pid, signal.SIGTERM)
+
+    expected_records = [
+        {"msg": "subprocess.Popen"},
+        {
+            "msg": "os.kill",
+            "audit.args.pid": process.pid,
+            "audit.args.sig": signal.SIGTERM,
+        },
+    ]
+
+    assert len(caplog.records) == len(expected_records)
+    for record, expected_record in zip(caplog.records, expected_records):
+        assert record.levelname == "AUDIT"
+        assert_record_match(record, expected_record)
+
+
 def test_do_not_log_popen_env(
-    init_audit_hook,
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    init_audit_hook, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("FOO", "SENSITIVE-DATA")
     subprocess.Popen(["ls"], env=os.environ)


### PR DESCRIPTION
## Ticket

Resolves #117 

## Changes
- Spin up test process to kill rather than using a random pid

## Context for reviewers
@chouinar discovered this bug (see ticket description)

## Testing
CI and also ran `poetry run pytest` (didn't address other test failures when running outside container, will look at those nest)