### PR TITLE
Isolate audit logging tests from rest of test suite

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -36,4 +36,7 @@ jobs:
         run: make lint-security
 
       - name: Start tests
-        run: make test-coverage
+        run: |
+          make test-audit
+          make test-coverage
+        

--- a/app/Makefile
+++ b/app/Makefile
@@ -121,14 +121,17 @@ db-migrate-heads: ## Show migrations marked as a head
 # Testing
 ##################################################
 
-test:
-	$(PY_RUN_CMD) pytest $(args)
+test: ## Run all tests except for audit logging tests
+	$(PY_RUN_CMD) pytest -m "not audit" $(args)
+
+test-audit: ## Run audit logging tests
+	$(PY_RUN_CMD) pytest -m "audit" $(args)
 
 test-watch:
 	$(PY_RUN_CMD) pytest-watch --clear $(args)
 
 test-coverage:
-	$(PY_RUN_CMD) coverage run --branch --source=api -m pytest $(args)
+	$(PY_RUN_CMD) coverage run --branch --source=api -m pytest -m "not audit" $(args)
 	$(PY_RUN_CMD) coverage report
 
 test-coverage-report: ## Open HTML test coverage report

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -100,5 +100,8 @@ filterwarnings = [
   "ignore::DeprecationWarning:apispec.*",
   "ignore::DeprecationWarning:certifi.*"] # pytest-watch errors if the closing bracket is on it's own line
 
+markers = [
+  "audit: mark a test as a security audit log test, to be run isolated from other tests"]
+
 [tool.coverage.run]
 omit = ["api/db/migrations/*.py"]

--- a/app/tests/api/logging/test_audit.py
+++ b/app/tests/api/logging/test_audit.py
@@ -144,7 +144,7 @@ def test_audit_hook(
 
 def test_os_kill(init_audit_hook, caplog: pytest.LogCaptureFixture):
     # Start a process to kill
-    process = subprocess.Popen("ls")
+    process = subprocess.Popen("cat")
     os.kill(process.pid, signal.SIGTERM)
 
     expected_records = [

--- a/app/tests/api/logging/test_audit.py
+++ b/app/tests/api/logging/test_audit.py
@@ -41,18 +41,6 @@ test_audit_hook_data = [
         id="open",
     ),
     pytest.param(
-        os.kill,
-        (-1, signal.SIGTERM),  # Using PID=-1 since it should not ever be a valid PID
-        [
-            {
-                "msg": "os.kill",
-                "audit.args.pid": -1,
-                "audit.args.sig": signal.SIGTERM,
-            }
-        ],
-        id="os.kill",
-    ),
-    pytest.param(
         os.rename,
         ("/tmp/oldname", "/tmp/newname"),
         [
@@ -154,10 +142,28 @@ def test_audit_hook(
         assert_record_match(record, expected_record)
 
 
+def test_os_kill(init_audit_hook, caplog: pytest.LogCaptureFixture):
+    # Start a process to kill
+    process = subprocess.Popen("ls")
+    os.kill(process.pid, signal.SIGTERM)
+
+    expected_records = [
+        {"msg": "subprocess.Popen"},
+        {
+            "msg": "os.kill",
+            "audit.args.pid": process.pid,
+            "audit.args.sig": signal.SIGTERM,
+        },
+    ]
+
+    assert len(caplog.records) == len(expected_records)
+    for record, expected_record in zip(caplog.records, expected_records):
+        assert record.levelname == "AUDIT"
+        assert_record_match(record, expected_record)
+
+
 def test_do_not_log_popen_env(
-    init_audit_hook,
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    init_audit_hook, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("FOO", "SENSITIVE-DATA")
     subprocess.Popen(["ls"], env=os.environ)

--- a/app/tests/api/logging/test_audit.py
+++ b/app/tests/api/logging/test_audit.py
@@ -18,6 +18,12 @@ import pytest
 
 import api.logging.audit as audit
 
+# Do not run these tests alongside the rest of the test suite since
+# this tests adds an audit hook that interfere with other tests,
+# and at the time of writing there isn't a known way to remove
+# audit hooks.
+pytestmark = pytest.mark.audit
+
 
 @pytest.fixture(scope="session")
 def init_audit_hook():
@@ -35,7 +41,6 @@ test_audit_hook_data = [
                 "msg": "open",
                 "audit.args.path": "/dev/null",
                 "audit.args.mode": "w",
-                "audit.args.flags": 524865,
             }
         ],
         id="open",
@@ -72,7 +77,6 @@ test_audit_hook_data = [
                 "msg": "open",
                 "audit.args.path": "/dev/null",
                 "audit.args.mode": None,
-                "audit.args.flags": 524354,
             }
         ],
         id="os.open",


### PR DESCRIPTION
## Ticket

N/A

## Changes
- Add "audit" pytest marker
- Mark audit logging tests with the "audit" pytest marker
- Run non-audit tests in make test and make test-coverage
- Add make test-audit for running audit logging tests only
- Run make test-audit in ci-app.yml

## Context for reviewers
Since it's infeasible (as far as we know) to clean up / remove the audithook after each audit log test, the audit log tests end up interfering with the other tests in unpredictable ways. The impact of this includes test crashes and noisy logs. This change isolates the audit log tests into it's own test suite.

🔒 [see slack thread](https://nava.slack.com/archives/C03G1SWD9H7/p1675441772644679?thread_ts=1675439825.157059&cid=C03G1SWD9H7)

## Testing
Ran make test, make test-audit, make test-coverage, and also ran them outside of Docker

Note that some tests still fail outside of Docker, that's a separate issue