### PR TITLE
Remove redundant setting of db env vars

### DIFF
--- a/app/tests/lib/db_testing.py
+++ b/app/tests/lib/db_testing.py
@@ -18,10 +18,6 @@ def create_isolated_db(monkeypatch) -> None:
     """
     schema_name = f"test_schema_{uuid.uuid4().int}"
     monkeypatch.setenv("DB_SCHEMA", schema_name)
-    monkeypatch.setenv("POSTGRES_DB", "main-db")
-    monkeypatch.setenv("POSTGRES_USER", "local_db_user")
-    monkeypatch.setenv("POSTGRES_PASSWORD", "secret123")
-    monkeypatch.setenv("ENVIRONMENT", "local")
 
     # To improve test performance, don't check the database connection
     # when initializing the DB client.


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
The PR #122 introduced an autouse fixture that loaded local.env during tests.
As a result, most of the env vars set while creating the isolated DB schema are no longer necessary.
This PR removes those redundant env vars and DRY's things up a bit, making the resulting function
easier to read and understand.

## Testing
Run `make test` and `poetry run pytest -m "not audit"` (running tests both inside and outside of Docker)
