### PR TITLE
Fix log interpolation for JSONFormatter and HumanReadableFormatter

### DIFF
--- a/app/api/logging/formatters.py
+++ b/app/api/logging/formatters.py
@@ -27,11 +27,12 @@ class HumanReadableFormatter(logging.Formatter):
     """
 
     def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
         return decodelog.format_line(
             datetime.utcfromtimestamp(record.created),
             record.name,
             record.funcName,
             record.levelname,
-            record.msg,
+            message,
             record.__dict__,
         )

--- a/app/api/logging/formatters.py
+++ b/app/api/logging/formatters.py
@@ -18,6 +18,9 @@ class JsonFormatter(logging.Formatter):
     """A logging formatter which formats each line as JSON."""
 
     def format(self, record: logging.LogRecord) -> str:
+        # logging.Formatter.format adds the `message` attribute to the LogRecord
+        # see https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L690-L720
+        super().format(record)
         return json.dumps(record.__dict__, separators=(",", ":"))
 
 

--- a/app/tests/api/logging/test_formatters.py
+++ b/app/tests/api/logging/test_formatters.py
@@ -14,12 +14,13 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
     console_handler.setFormatter(formatters.JsonFormatter())
     logger.addHandler(console_handler)
 
-    logger.warning("hello", extra={"foo": "bar"})
+    logger.warning("hello %s", "interpolated_string", extra={"foo": "bar"})
 
     json_record = json.loads(capsys.readouterr().err)
     expected = {
         "name": "test_json_formatter",
-        "msg": "hello",
+        "message": "hello interpolated_string",
+        "msg": "hello %s",
         "levelname": "WARNING",
         "levelno": 30,
         "filename": "test_formatters.py",

--- a/app/tests/api/logging/test_formatters.py
+++ b/app/tests/api/logging/test_formatters.py
@@ -36,10 +36,10 @@ def test_human_readable_formatter(capsys: pytest.CaptureFixture):
     console_handler.setFormatter(formatters.HumanReadableFormatter())
     logger.addHandler(console_handler)
 
-    logger.warning("hello", extra={"foo": "bar"})
+    logger.warning("hello %s", "interpolated_string", extra={"foo": "bar"})
 
     text = capsys.readouterr().err
     assert re.match(
-        r"\d{2}:\d{2}:\d{2}\.\d{3}  test_human_readable_formatter       \x1b\[0m test_human_readable_formatter \x1b\[31mWARNING  hello                                                                            \x1b\[34mfoo=bar\x1b\[0m\n",
+        r"\d{2}:\d{2}:\d{2}\.\d{3}  test_human_readable_formatter       \x1b\[0m test_human_readable_formatter \x1b\[31mWARNING  hello interpolated_string                                                        \x1b\[34mfoo=bar\x1b\[0m\n",
         text,
     )


### PR DESCRIPTION
## Ticket

Resolves #129 

## Changes
- Fix log interpolation for JSONFormatter and HumanReadableFormatter

## Context for reviewers
this was reported in slack 🔒 [thread](https://nava.slack.com/archives/C03G1SWD9H7/p1675439828424959?thread_ts=1675439825.157059&cid=C03G1SWD9H7)

## Testing
modified the tests to include interpolation scenario
