### PR TITLE
Add test for response.time

### DIFF
--- a/app/api/logging/flask_logger.py
+++ b/app/api/logging/flask_logger.py
@@ -17,7 +17,7 @@ Usage:
     flask_logger.init_app(logger, app)
 """
 import logging
-from time import perf_counter
+import time
 
 import flask
 
@@ -76,7 +76,7 @@ def add_extra_data_to_current_request_logs(
 
 def _track_request_start_time() -> None:
     """Store the request start time in flask.g"""
-    flask.g.request_start_time = perf_counter()
+    flask.g.request_start_time = time.perf_counter()
 
 
 def _log_start_request() -> None:
@@ -108,7 +108,7 @@ def _log_end_request(response: flask.Response) -> flask.Response:
             "response.content_length": response.content_length,
             "response.content_type": response.content_type,
             "response.mimetype": response.mimetype,
-            "response.time_ms": (perf_counter() - flask.g.request_start_time) * 1000,
+            "response.time_ms": (time.perf_counter() - flask.g.request_start_time) * 1000,
         },
     )
     return response

--- a/app/tests/api/logging/test_flask_logger.py
+++ b/app/tests/api/logging/test_flask_logger.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import time
 
 import pytest
 from flask import Flask
@@ -121,3 +122,20 @@ def test_add_extra_log_data_for_current_request(app: Flask, caplog: pytest.LogCa
 
     last_record = caplog.records[-1]
     assert_dict_contains(last_record.__dict__, {"pet.name": "kitty"})
+
+
+def test_log_response_time(app: Flask, caplog: pytest.LogCaptureFixture):
+    @app.get("/sleep")
+    def sleep():
+        time.sleep(0.1)  # 0.1 s = 100 ms
+        return "ok"
+
+    app.test_client().get("/sleep")
+
+    last_record = caplog.records[-1]
+    assert "response.time_ms" in last_record.__dict__
+    response_time_ms = last_record.__dict__["response.time_ms"]
+    expected_response_time_ms = 100  # ms
+    allowed_error = 20  # ms
+
+    assert response_time_ms == pytest.approx(expected_response_time_ms, abs=allowed_error)


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
PR #134 added response.time to the response logs. i realize it might be nice to add a quick unit test for it. the unit test leverages sleep so it's not great but it's only a 100ms test and i figure we won't have many tests like this so 🤷 

## Testing
CI
