### PR TITLE
Make fixes to the logging setup for testing

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def create_app() -> APIFlask:
     app = APIFlask(__name__)
 
-    src.logging.Log(__package__)
+    src.logging.init(__package__)
     flask_logger.init_app(logging.root, app)
 
     db_client = db.PostgresDBClient()

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 def create_app() -> APIFlask:
     app = APIFlask(__name__)
 
-    root_logger = src.logging.Log(__package__).root_logger
-    flask_logger.init_app(root_logger, app)
+    src.logging.Log(__package__)
+    flask_logger.init_app(logging.root, app)
 
     db_client = db.init()
     flask_db.init_app(db_client, app)

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def create_app() -> APIFlask:
     app = APIFlask(__name__)
 
-    root_logger = src.logging.init(__package__)
+    root_logger = src.logging.Log(__package__).root_logger
     flask_logger.init_app(root_logger, app)
 
     db_client = db.init()

--- a/app/src/db/migrations/env.py
+++ b/app/src/db/migrations/env.py
@@ -27,7 +27,7 @@ config = context.config
 logger = logging.getLogger("migrations")
 
 # Initialize logging
-with src.logging.Log("migrations"):
+with src.logging.init("migrations"):
 
     if not config.get_main_option("sqlalchemy.url"):
         uri = make_connection_uri(get_db_config())

--- a/app/src/db/migrations/env.py
+++ b/app/src/db/migrations/env.py
@@ -27,88 +27,88 @@ config = context.config
 logger = logging.getLogger("migrations")
 
 # Initialize logging
-src.logging.init("migrations")
+with src.logging.Log("migrations"):
 
-if not config.get_main_option("sqlalchemy.url"):
-    uri = make_connection_uri(get_db_config())
+    if not config.get_main_option("sqlalchemy.url"):
+        uri = make_connection_uri(get_db_config())
 
-    # Escape percentage signs in the URI.
-    # https://alembic.sqlalchemy.org/en/latest/api/config.html#alembic.config.Config.set_main_option
-    config.set_main_option("sqlalchemy.url", uri.replace("%", "%%"))
+        # Escape percentage signs in the URI.
+        # https://alembic.sqlalchemy.org/en/latest/api/config.html#alembic.config.Config.set_main_option
+        config.set_main_option("sqlalchemy.url", uri.replace("%", "%%"))
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-target_metadata = metadata
+    # add your model's MetaData object here
+    # for 'autogenerate' support
+    # from myapp import mymodel
+    # target_metadata = mymodel.Base.metadata
+    target_metadata = metadata
 
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+    # other values from the config, defined by the needs of env.py,
+    # can be acquired:
+    # my_important_option = config.get_main_option("my_important_option")
+    # ... etc.
 
+    def include_object(
+        object: sqlalchemy.schema.SchemaItem,
+        name: str,
+        type_: str,
+        reflected: bool,
+        compare_to: Any,
+    ) -> bool:
+        if type_ == "schema" and getattr(object, "schema", None) is not None:
+            return False
+        else:
+            return True
 
-def include_object(
-    object: sqlalchemy.schema.SchemaItem, name: str, type_: str, reflected: bool, compare_to: Any
-) -> bool:
-    if type_ == "schema" and getattr(object, "schema", None) is not None:
-        return False
-    else:
-        return True
+    def run_migrations_offline() -> None:
+        """Run migrations in 'offline' mode.
 
+        This configures the context with just a URL
+        and not an Engine, though an Engine is acceptable
+        here as well.  By skipping the Engine creation
+        we don't even need a DBAPI to be available.
 
-def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
+        Calls to context.execute() here emit the given string to the
+        script output.
 
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
+        """
 
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
-
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url,
-        target_metadata=target_metadata,
-        literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
-        include_schemas=False,
-        include_object=include_object,
-        compare_type=True,
-    )
-
-    with context.begin_transaction():
-        context.run_migrations()
-
-
-def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
-
-    url = config.get_main_option("sqlalchemy.url", "SQLAlchemy URL not set")
-    connectable = sqlalchemy.create_engine(url)
-
-    with connectable.connect() as connection:
+        url = config.get_main_option("sqlalchemy.url")
         context.configure(
-            connection=connection,
+            url=url,
             target_metadata=target_metadata,
+            literal_binds=True,
+            dialect_opts={"paramstyle": "named"},
             include_schemas=False,
             include_object=include_object,
             compare_type=True,
         )
+
         with context.begin_transaction():
             context.run_migrations()
 
+    def run_migrations_online() -> None:
+        """Run migrations in 'online' mode.
 
-if context.is_offline_mode():
-    run_migrations_offline()
-else:
-    run_migrations_online()
+        In this scenario we need to create an Engine
+        and associate a connection with the context.
+
+        """
+
+        url = config.get_main_option("sqlalchemy.url", "SQLAlchemy URL not set")
+        connectable = sqlalchemy.create_engine(url)
+
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                include_schemas=False,
+                include_object=include_object,
+                compare_type=True,
+            )
+            with context.begin_transaction():
+                context.run_migrations()
+
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()

--- a/app/src/logging/__init__.py
+++ b/app/src/logging/__init__.py
@@ -39,15 +39,14 @@ _original_argv = tuple(sys.argv)
 
 class Log:
     def __init__(self, program_name: str) -> None:
-        self.program_name = program_name
-        self.root_logger, self.stream_handler = config.configure_logging()
-        log_program_info(self.program_name)
+        self.stream_handler = config.configure_logging()
+        log_program_info(program_name)
 
-    def __enter__(self) -> logging.Logger:
-        return self.root_logger
+    def __enter__(self) -> None:
+        return None
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.root_logger.removeHandler(self.stream_handler)
+        logging.root.removeHandler(self.stream_handler)
 
 
 def log_program_info(program_name: str) -> None:

--- a/app/src/logging/__init__.py
+++ b/app/src/logging/__init__.py
@@ -11,7 +11,8 @@ src.logging.pii for more information.
 Usage:
     import src.logging
 
-    src.logging.init("program name")
+    with src.logging.Log("program name"):
+        ...
 
 Once the module has been initialized, the standard logging module can be
 used to log messages:
@@ -36,11 +37,17 @@ logger = logging.getLogger(__name__)
 _original_argv = tuple(sys.argv)
 
 
-def init(program_name: str) -> logging.Logger:
-    root_logger = config.configure_logging()
+class Log:
+    def __init__(self, program_name: str) -> None:
+        self.program_name = program_name
+        self.root_logger, self.stream_handler = config.configure_logging()
+        log_program_info(self.program_name)
 
-    log_program_info(program_name)
-    return root_logger
+    def __enter__(self) -> logging.Logger:
+        return self.root_logger
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.root_logger.removeHandler(self.stream_handler)
 
 
 def log_program_info(program_name: str) -> None:

--- a/app/src/logging/__init__.py
+++ b/app/src/logging/__init__.py
@@ -11,7 +11,7 @@ src.logging.pii for more information.
 Usage:
     import src.logging
 
-    with src.logging.Log("program name"):
+    with src.logging.init("program name"):
         ...
 
 Once the module has been initialized, the standard logging module can be
@@ -24,56 +24,9 @@ Example:
     logger.info("message")
 """
 
-import logging
-import os
-import platform
-import pwd
-import sys
-from typing import Any, cast
 
 import src.logging.config as config
 
-logger = logging.getLogger(__name__)
-_original_argv = tuple(sys.argv)
 
-
-class Log:
-    def __init__(self, program_name: str) -> None:
-        self.stream_handler = config.configure_logging()
-        log_program_info(program_name)
-
-    def __enter__(self) -> None:
-        return None
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        logging.root.removeHandler(self.stream_handler)
-
-
-def log_program_info(program_name: str) -> None:
-    logger.info(
-        "start %s: %s %s %s, hostname %s, pid %i, user %i(%s)",
-        program_name,
-        platform.python_implementation(),
-        platform.python_version(),
-        platform.system(),
-        platform.node(),
-        os.getpid(),
-        os.getuid(),
-        pwd.getpwuid(os.getuid()).pw_name,
-        extra={
-            "hostname": platform.node(),
-            "cpu_count": os.cpu_count(),
-            # If mypy is run on a mac, it will throw a module has no attribute error, even though
-            # we never actually access it with the conditional.
-            #
-            # However, we can't just silence this error, because on linux (e.g. CI/CD) that will
-            # throw an unused “type: ignore” comment error. Casting to Any instead ensures this
-            # passes regardless of where mypy is being run
-            "cpu_usable": (
-                len(cast(Any, os).sched_getaffinity(0))
-                if "sched_getaffinity" in dir(os)
-                else "unknown"
-            ),
-        },
-    )
-    logger.info("invoked as: %s", " ".join(_original_argv))
+def init(program_name: str) -> config.LoggingContext:
+    return config.LoggingContext(program_name)

--- a/app/src/logging/audit.py
+++ b/app/src/logging/audit.py
@@ -32,7 +32,7 @@ def handle_audit_event(event_name: str, args: tuple[Any, ...]) -> None:
     EVENTS_TO_LOG = {
         # Detect dynamic execution of code objects. This only occurs for explicit
         # calls, and is not raised for normal function invocation.
-        # "exec": ("code_object",), TODO - this can't be logged as a code object isn't serializable
+        "exec": ("code_object",),  # TODO - this can't be logged as a code object isn't serializable
         # Detect when a file is about to be opened. path and mode are the usual
         # parameters to open if available, while flags is provided instead of
         # mode in some cases.

--- a/app/src/logging/audit.py
+++ b/app/src/logging/audit.py
@@ -32,7 +32,7 @@ def handle_audit_event(event_name: str, args: tuple[Any, ...]) -> None:
     EVENTS_TO_LOG = {
         # Detect dynamic execution of code objects. This only occurs for explicit
         # calls, and is not raised for normal function invocation.
-        "exec": ("code_object",),
+        # "exec": ("code_object",), TODO - this can't be logged as a code object isn't serializable
         # Detect when a file is about to be opened. path and mode are the usual
         # parameters to open if available, while flags is provided instead of
         # mode in some cases.

--- a/app/src/logging/config.py
+++ b/app/src/logging/config.py
@@ -1,5 +1,9 @@
 import logging
+import os
+import platform
+import pwd
 import sys
+from typing import Any, ContextManager, cast
 
 import src.logging.audit
 import src.logging.formatters as formatters
@@ -8,7 +12,7 @@ from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
 
-is_initialized = False
+_original_argv = tuple(sys.argv)
 
 
 class HumanReadableFormatterConfig(PydanticBaseEnvConfig):
@@ -26,41 +30,77 @@ class LoggingConfig(PydanticBaseEnvConfig):
         env_nested_delimiter = "__"
 
 
-def configure_logging() -> logging.Handler:
-    """Configure logging for the application.
-
-    Configures the root module logger to log to stdout.
-    Adds a PII mask filter to the root logger.
-    Also configures log levels third party packages.
+class LoggingContext(ContextManager[None]):
     """
-    config = LoggingConfig()
+    A context manager for handling setting up the logging stream.
 
-    # Loggers can be configured using config functions defined
-    # in logging.config or by directly making calls to the main API
-    # of the logging module (see https://docs.python.org/3/library/logging.config.html)
-    # We opt to use the main API using functions like `addHandler` which is
-    # non-destructive, i.e. it does not overwrite any existing handlers.
-    # In contrast, logging.config.dictConfig() would overwrite any existing loggers.
-    # This is important during testing, since fixtures like `caplog` add handlers that would
-    # get overwritten if we call logging.config.dictConfig() during the scope of the test.
-    console_handler = logging.StreamHandler(sys.stdout)
-    formatter = get_formatter(config)
-    console_handler.setFormatter(formatter)
-    console_handler.addFilter(pii.mask_pii)
-    logging.root.removeHandler(console_handler)
-    logging.root.addHandler(console_handler)
-    logging.root.setLevel(config.level)
+    To help facillitate being able to test logging, we need to be able
+    to easily create temporary output streams and then tear them down.
 
-    if config.enable_audit:
-        src.logging.audit.init()
+    When this context manager is torn down, the stream handler created
+    with it will be removed.
 
-    # Configure loggers for third party packages
-    logging.getLogger("alembic").setLevel(logging.INFO)
-    logging.getLogger("werkzeug").setLevel(logging.WARN)
-    logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
-    logging.getLogger("sqlalchemy.dialects.postgresql").setLevel(logging.INFO)
+    For example:
+    ```py
+    import logging
 
-    return console_handler
+    logger = logging.getLogger(__name__)
+
+    with LoggingContext("example_program_name"):
+        # This log message will go to stdout
+        logger.info("example log message")
+
+    # This log message won't go to stdout as the
+    # handler will have been removed
+    logger.info("example log message")
+    ```
+    Note that any other handlers added to the root logger won't be affected
+    and calling this multiple times before exit would result in duplicate logs.
+    """
+
+    def __init__(self, program_name: str) -> None:
+        self._configure_logging()
+        log_program_info(program_name)
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        # Remove the console handler to stop logs from being sent to stdout
+        logging.root.removeHandler(self.console_handler)
+
+    def _configure_logging(self) -> None:
+        """Configure logging for the application.
+
+        Configures the root module logger to log to stdout.
+        Adds a PII mask filter to the root logger.
+        Also configures log levels third party packages.
+        """
+        config = LoggingConfig()
+
+        # Loggers can be configured using config functions defined
+        # in logging.config or by directly making calls to the main API
+        # of the logging module (see https://docs.python.org/3/library/logging.config.html)
+        # We opt to use the main API using functions like `addHandler` which is
+        # non-destructive, i.e. it does not overwrite any existing handlers.
+        # In contrast, logging.config.dictConfig() would overwrite any existing loggers.
+        # This is important during testing, since fixtures like `caplog` add handlers that would
+        # get overwritten if we call logging.config.dictConfig() during the scope of the test.
+        self.console_handler = logging.StreamHandler(sys.stdout)
+        formatter = get_formatter(config)
+        self.console_handler.setFormatter(formatter)
+        self.console_handler.addFilter(pii.mask_pii)
+        logging.root.addHandler(self.console_handler)
+        logging.root.setLevel(config.level)
+
+        if config.enable_audit:
+            src.logging.audit.init()
+
+        # Configure loggers for third party packages
+        logging.getLogger("alembic").setLevel(logging.INFO)
+        logging.getLogger("werkzeug").setLevel(logging.WARN)
+        logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
+        logging.getLogger("sqlalchemy.dialects.postgresql").setLevel(logging.INFO)
 
 
 def get_formatter(config: LoggingConfig) -> logging.Formatter:
@@ -72,6 +112,36 @@ def get_formatter(config: LoggingConfig) -> logging.Formatter:
     if config.format == "human-readable":
         return get_human_readable_formatter(config.human_readable_formatter)
     return formatters.JsonFormatter()
+
+
+def log_program_info(program_name: str) -> None:
+    logger.info(
+        "start %s: %s %s %s, hostname %s, pid %i, user %i(%s)",
+        program_name,
+        platform.python_implementation(),
+        platform.python_version(),
+        platform.system(),
+        platform.node(),
+        os.getpid(),
+        os.getuid(),
+        pwd.getpwuid(os.getuid()).pw_name,
+        extra={
+            "hostname": platform.node(),
+            "cpu_count": os.cpu_count(),
+            # If mypy is run on a mac, it will throw a module has no attribute error, even though
+            # we never actually access it with the conditional.
+            #
+            # However, we can't just silence this error, because on linux (e.g. CI/CD) that will
+            # throw an unused “type: ignore” comment error. Casting to Any instead ensures this
+            # passes regardless of where mypy is being run
+            "cpu_usable": (
+                len(cast(Any, os).sched_getaffinity(0))
+                if "sched_getaffinity" in dir(os)
+                else "unknown"
+            ),
+        },
+    )
+    logger.info("invoked as: %s", " ".join(_original_argv))
 
 
 def get_human_readable_formatter(

--- a/app/src/logging/config.py
+++ b/app/src/logging/config.py
@@ -57,6 +57,7 @@ def configure_logging() -> logging.Logger:
     logging.getLogger("werkzeug").setLevel(logging.WARN)
     logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
     logging.getLogger("sqlalchemy.dialects.postgresql").setLevel(logging.INFO)
+    logging.getLogger("src.services").setLevel(logging.ERROR)
 
     return logging.root
 

--- a/app/src/logging/config.py
+++ b/app/src/logging/config.py
@@ -63,10 +63,13 @@ class LoggingContext(ContextManager[None]):
         log_program_info(program_name)
 
     def __enter__(self) -> None:
-        return None
+        pass
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         # Remove the console handler to stop logs from being sent to stdout
+        # This is useful in the test suite, since multiple tests may initialize
+        # separate duplicate handlers. This allows for easier cleanup for each
+        # of those tests.
         logging.root.removeHandler(self.console_handler)
 
     def _configure_logging(self) -> None:

--- a/app/src/logging/config.py
+++ b/app/src/logging/config.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from typing import Tuple
 
 import src.logging.audit
 import src.logging.formatters as formatters
@@ -27,7 +26,7 @@ class LoggingConfig(PydanticBaseEnvConfig):
         env_nested_delimiter = "__"
 
 
-def configure_logging() -> Tuple[logging.Logger, logging.Handler]:
+def configure_logging() -> logging.Handler:
     """Configure logging for the application.
 
     Configures the root module logger to log to stdout.
@@ -61,7 +60,7 @@ def configure_logging() -> Tuple[logging.Logger, logging.Handler]:
     logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
     logging.getLogger("sqlalchemy.dialects.postgresql").setLevel(logging.INFO)
 
-    return logging.root, console_handler
+    return console_handler
 
 
 def get_formatter(config: LoggingConfig) -> logging.Formatter:

--- a/app/src/logging/flask_logger.py
+++ b/app/src/logging/flask_logger.py
@@ -42,6 +42,7 @@ def init_app(app_logger: logging.Logger, app: flask.Flask) -> None:
 
         flask_logger.init_app(logger, app)
     """
+
     # Need to add filters to each of the handlers rather than to the logger itself, since
     # messages are passed directly to the ancestor loggers’ handlers bypassing any filters
     # set on the ancestors.

--- a/app/src/logging/formatters.py
+++ b/app/src/logging/formatters.py
@@ -6,14 +6,13 @@ be used used during development.
 
 See https://docs.python.org/3/library/logging.html#formatter-objects
 """
-import pydantic
-import pydantic.json
 import json
 import logging
 from datetime import datetime
 
-import src.logging.decodelog as decodelog
+from pydantic.json import pydantic_encoder
 
+import src.logging.decodelog as decodelog
 
 
 class JsonFormatter(logging.Formatter):
@@ -24,11 +23,7 @@ class JsonFormatter(logging.Formatter):
         # see https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L690-L720
         super().format(record)
 
-        x = json.dumps(record.__dict__, separators=(",", ":"), default=pydantic.json.pydantic_encoder)
-        print("*"*50)
-        print(record.__dict__)
-        return x
-
+        return json.dumps(record.__dict__, separators=(",", ":"), default=pydantic_encoder)
 
 
 HUMAN_READABLE_FORMATTER_DEFAULT_MESSAGE_WIDTH = decodelog.DEFAULT_MESSAGE_WIDTH

--- a/app/src/logging/formatters.py
+++ b/app/src/logging/formatters.py
@@ -6,12 +6,14 @@ be used used during development.
 
 See https://docs.python.org/3/library/logging.html#formatter-objects
 """
-
+import pydantic
+import pydantic.json
 import json
 import logging
 from datetime import datetime
 
 import src.logging.decodelog as decodelog
+
 
 
 class JsonFormatter(logging.Formatter):
@@ -21,7 +23,12 @@ class JsonFormatter(logging.Formatter):
         # logging.Formatter.format adds the `message` attribute to the LogRecord
         # see https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L690-L720
         super().format(record)
-        return json.dumps(record.__dict__, separators=(",", ":"))
+
+        x = json.dumps(record.__dict__, separators=(",", ":"), default=pydantic.json.pydantic_encoder)
+        print("*"*50)
+        print(record.__dict__)
+        return x
+
 
 
 HUMAN_READABLE_FORMATTER_DEFAULT_MESSAGE_WIDTH = decodelog.DEFAULT_MESSAGE_WIDTH

--- a/app/src/logging/formatters.py
+++ b/app/src/logging/formatters.py
@@ -11,14 +11,16 @@ import logging
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Callable, Type
+from typing import Any, Callable, Type, TypeVar
 from uuid import UUID
 
 import src.logging.decodelog as decodelog
 
+T = TypeVar("T")
 
-# identity returns unmodified value
-def identity(obj: Any) -> Any:
+
+# identity returns an unmodified object
+def identity(obj: T) -> T:
     return obj
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -17,7 +17,7 @@ from tests.lib import db_testing
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def env_vars():
     load_local_env_vars()
 
@@ -83,7 +83,6 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
     this fixture.
     """
     monkeypatch.setattr(factories, "_db_session", db_session)
-    logger.info("set factories db_session to %s", db_session)
     return db_session
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -19,6 +19,26 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session", autouse=True)
 def env_vars():
+    """
+    Default environment variables for tests to be
+    based on the local.env file. These get set once
+    before all tests run. As "session" is the highest
+    scope, this will run before any other explicit fixtures
+    in a test.
+
+    See: https://docs.pytest.org/en/6.2.x/fixture.html#autouse-order
+
+    To set a different environment variable for a test,
+    use the monkeypatch fixture, for example:
+
+    ```py
+    def test_example(monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "debug")
+    ```
+
+    Several monkeypatch fixtures exists below for different
+    scope levels.
+    """
     load_local_env_vars()
 
 

--- a/app/tests/src/logging/test_audit.py
+++ b/app/tests/src/logging/test_audit.py
@@ -31,8 +31,8 @@ def init_audit_hook():
 
 
 test_audit_hook_data = [
-    pytest.param(eval, ("1+1", None, None), [{"msg": "exec"}], id="eval"),
-    pytest.param(exec, ("1+1", None, None), [{"msg": "exec"}], id="exec"),
+    # pytest.param(eval, ("1+1", None, None), [{"msg": "exec"}], id="eval"), TODO - can't serialize exec
+    # pytest.param(exec, ("1+1", None, None), [{"msg": "exec"}], id="exec"), TODO - can't serialize exec
     pytest.param(
         open,
         ("/dev/null", "w"),
@@ -199,9 +199,6 @@ def test_repeated_audit_logs(
 
     for _ in range(1000):
         open(tmp_path / "repeated-audit-logs", "w")
-
-    for r in caplog.records:
-        print(r.__dict__["msg"], r.__dict__["count"])
 
     expected_records = [
         {"msg": "open", "count": 1},

--- a/app/tests/src/logging/test_audit.py
+++ b/app/tests/src/logging/test_audit.py
@@ -31,8 +31,8 @@ def init_audit_hook():
 
 
 test_audit_hook_data = [
-    # pytest.param(eval, ("1+1", None, None), [{"msg": "exec"}], id="eval"), TODO - can't serialize exec
-    # pytest.param(exec, ("1+1", None, None), [{"msg": "exec"}], id="exec"), TODO - can't serialize exec
+    pytest.param(eval, ("1+1", None, None), [{"msg": "exec"}], id="eval"),
+    pytest.param(exec, ("1+1", None, None), [{"msg": "exec"}], id="exec"),
     pytest.param(
         open,
         ("/dev/null", "w"),

--- a/app/tests/src/logging/test_flask_logger.py
+++ b/app/tests/src/logging/test_flask_logger.py
@@ -12,9 +12,14 @@ from tests.lib.assertions import assert_dict_contains
 @pytest.fixture
 def logger():
     logger = logging.getLogger("src")
+    before_level = logger.level
+
     logger.setLevel(logging.DEBUG)
-    logger.addHandler(logging.StreamHandler(sys.stdout))
-    return logger
+    handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler)
+    yield logger
+    logger.setLevel(before_level)
+    logger.removeHandler(handler)
 
 
 @pytest.fixture

--- a/app/tests/src/logging/test_formatters.py
+++ b/app/tests/src/logging/test_formatters.py
@@ -22,6 +22,7 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
     decimal_field = Decimal("12.34567")
     uuid_field = uuid4()
     set_field = {uuid4(), uuid4()}
+    list_field = [1, 2, 3, 4]
     exception_field = ValueError("my exception message")
     logger.warning(
         "hello %s",
@@ -36,6 +37,7 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
             "decimal_field": decimal_field,
             "uuid_field": uuid_field,
             "set_field": set_field,
+            "list_field": list_field,
             "exception_field": exception_field,
         },
     )
@@ -60,6 +62,7 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
         "decimal_field": str(decimal_field),
         "uuid_field": str(uuid_field),
         "set_field": [str(u) for u in set_field],
+        "list_field": list_field,
         "exception_field": str(exception_field),
     }
     assert_dict_contains(json_record, expected)

--- a/app/tests/src/logging/test_formatters.py
+++ b/app/tests/src/logging/test_formatters.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import re
+from datetime import datetime
+from decimal import Decimal
+from uuid import uuid4
 
 import pytest
 
@@ -14,9 +17,31 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
     console_handler.setFormatter(formatters.JsonFormatter())
     logger.addHandler(console_handler)
 
-    logger.warning("hello %s", "interpolated_string", extra={"foo": "bar"})
+    datetime_now = datetime.now()
+    date_now = datetime_now.date()
+    decimal_field = Decimal("12.34567")
+    uuid_field = uuid4()
+    set_field = {uuid4(), uuid4()}
+    exception_field = ValueError("my exception message")
+    logger.warning(
+        "hello %s",
+        "interpolated_string",
+        extra={
+            "foo": "bar",
+            "int_field": 5,
+            "bool_field": True,
+            "none_field": None,
+            "datetime_field": datetime_now,
+            "date_field": date_now,
+            "decimal_field": decimal_field,
+            "uuid_field": uuid_field,
+            "set_field": set_field,
+            "exception_field": exception_field,
+        },
+    )
 
     json_record = json.loads(capsys.readouterr().err)
+
     expected = {
         "name": "test_json_formatter",
         "message": "hello interpolated_string",
@@ -27,6 +52,15 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
         "module": "test_formatters",
         "funcName": "test_json_formatter",
         "foo": "bar",
+        "int_field": 5,
+        "bool_field": True,
+        "none_field": None,
+        "datetime_field": datetime_now.isoformat(),
+        "date_field": date_now.isoformat(),
+        "decimal_field": str(decimal_field),
+        "uuid_field": str(uuid_field),
+        "set_field": [str(u) for u in set_field],
+        "exception_field": str(exception_field),
     }
     assert_dict_contains(json_record, expected)
     logger.removeHandler(console_handler)

--- a/app/tests/src/logging/test_formatters.py
+++ b/app/tests/src/logging/test_formatters.py
@@ -29,6 +29,7 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
         "foo": "bar",
     }
     assert_dict_contains(json_record, expected)
+    logger.removeHandler(console_handler)
 
 
 def test_human_readable_formatter(capsys: pytest.CaptureFixture):
@@ -47,3 +48,4 @@ def test_human_readable_formatter(capsys: pytest.CaptureFixture):
         rest
         == "  test_human_readable_formatter       \x1b[0m test_human_readable_formatter \x1b[31mWARNING \x1b[0m \x1b[31mhello interpolated_string                         \x1b[0m \x1b[34mfoo=bar\x1b[0m\n"
     )
+    logger.removeHandler(console_handler)

--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -11,7 +11,7 @@ import src.logging.formatters as formatters
 def init_test_logger(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch):
     caplog.set_level(logging.DEBUG)
     monkeypatch.setenv("LOG_FORMAT", "human-readable")
-    with src.logging.Log("test_logging"):
+    with src.logging.init("test_logging"):
         yield
 
 
@@ -26,7 +26,7 @@ def test_init(caplog: pytest.LogCaptureFixture, monkeypatch, log_format, expecte
     caplog.set_level(logging.DEBUG)
     monkeypatch.setenv("LOG_FORMAT", log_format)
 
-    with src.logging.Log("test_logging"):
+    with src.logging.init("test_logging"):
 
         records = caplog.records
         assert len(records) == 2

--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -11,8 +11,8 @@ import src.logging.formatters as formatters
 def init_test_logger(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch):
     caplog.set_level(logging.DEBUG)
     monkeypatch.setenv("LOG_FORMAT", "human-readable")
-    with src.logging.Log("test_logging") as log:
-        yield log
+    with src.logging.Log("test_logging"):
+        yield
 
 
 @pytest.mark.parametrize(

--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -7,19 +7,12 @@ import src.logging
 import src.logging.formatters as formatters
 
 
-def _init_test_logger(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, log_format="human-readable"
-):
-    caplog.set_level(logging.DEBUG)
-    monkeypatch.setenv("LOG_FORMAT", log_format)
-    src.logging.init("test_logging")
-
-
 @pytest.fixture
 def init_test_logger(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch):
-    _init_test_logger(caplog, monkeypatch)
-    yield
-    logging.root.handlers.clear()
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setenv("LOG_FORMAT", "human-readable")
+    with src.logging.Log("test_logging") as log:
+        yield log
 
 
 @pytest.mark.parametrize(
@@ -31,18 +24,20 @@ def init_test_logger(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.Monke
 )
 def test_init(caplog: pytest.LogCaptureFixture, monkeypatch, log_format, expected_formatter):
     caplog.set_level(logging.DEBUG)
-    _init_test_logger(caplog, monkeypatch, log_format)
+    monkeypatch.setenv("LOG_FORMAT", log_format)
 
-    records = caplog.records
-    assert len(records) == 2
-    assert re.match(
-        r"^start test_logging: \w+ [0-9.]+ \w+, hostname \S+, pid \d+, user \d+\(\w+\)$",
-        records[0].message,
-    )
-    assert re.match(r"^invoked as:", records[1].message)
+    with src.logging.Log("test_logging"):
 
-    formatter_types = [type(handler.formatter) for handler in logging.root.handlers]
-    assert expected_formatter in formatter_types
+        records = caplog.records
+        assert len(records) == 2
+        assert re.match(
+            r"^start test_logging: \w+ [0-9.]+ \w+, hostname \S+, pid \d+, user \d+\(\w+\)$",
+            records[0].message,
+        )
+        assert re.match(r"^invoked as:", records[1].message)
+
+        formatter_types = [type(handler.formatter) for handler in logging.root.handlers]
+        assert expected_formatter in formatter_types
 
 
 def test_log_exception(init_test_logger, caplog):


### PR DESCRIPTION
## Ticket

TODO

## Changes
Fix a few issues that were occurring when running tests with regards to logging.
1. Test formatting no longer is broken during tests and maintains the user configured values
2. Logs no longer get duplicated for every call to `logging.init`
3. Made logging init into a class that handles entry and exit

## Context for reviewers
todo

## Testing
TODO

Running `make test args="tests -s -vv"` now looks like:
![Screen Shot 2023-03-08 at 3 04 37 PM](https://user-images.githubusercontent.com/46358556/223835572-2ecd3385-328c-4a87-812a-d9828a79e3a1.png)

Which previously looked like:
![Screen Shot 2023-03-08 at 3 05 18 PM](https://user-images.githubusercontent.com/46358556/223835740-53c5d972-6349-439a-a695-7665cad4aa2a.png)
