### PR TITLE
Fix error when PII appears in interpolated logs

### DIFF
--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -85,10 +85,7 @@ def test_log_exception(init_test_logger, caplog):
         pytest.param(
             ("%s %s", "text", "123456789"),
             None,
-            {
-                "msg": "%s %s",
-                "message": "text *********",
-            },
+            {"message": "text *********"},
             id="pii in interpolation args",
         ),
     ],

--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -5,6 +5,7 @@ import pytest
 
 import src.logging
 import src.logging.formatters as formatters
+from tests.lib.assertions import assert_dict_contains
 
 
 @pytest.fixture
@@ -61,11 +62,33 @@ def test_log_exception(init_test_logger, caplog):
     assert last_record.__dict__["key2"] == "value2"
 
 
-def test_mask_pii(init_test_logger, caplog: pytest.LogCaptureFixture):
+@pytest.mark.parametrize(
+    "args,extra,expected",
+    [
+        (
+            ("pii",),
+            {"foo": "bar", "tin": "123456789", "dashed-ssn": "123-45-6789"},
+            {
+                "msg": "pii",
+                "foo": "bar",
+                "tin": "*********",
+                "dashed-ssn": "*********",
+            },
+        ),
+        (
+            ("%s %s", "text", "123456789"),
+            None,
+            {
+                "msg": "%s %s",
+                "message": "text *********",
+            },
+        ),
+    ],
+)
+def test_mask_pii(init_test_logger, caplog: pytest.LogCaptureFixture, args, extra, expected):
     logger = logging.getLogger(__name__)
 
-    logger.info("pii", extra={"foo": "bar", "tin": "123456789", "dashed-ssn": "123-45-6789"})
+    logger.info(*args, extra=extra)
 
     assert len(caplog.records) == 1
-    assert caplog.records[0].__dict__["tin"] == "*********"
-    assert caplog.records[0].__dict__["dashed-ssn"] == "*********"
+    assert_dict_contains(caplog.records[0].__dict__, expected)

--- a/app/tests/src/logging/test_logging.py
+++ b/app/tests/src/logging/test_logging.py
@@ -60,35 +60,3 @@ def test_log_exception(init_test_logger, caplog):
     assert last_record.exc_text.endswith("Exception: example exception")
     assert last_record.__dict__["key1"] == "value1"
     assert last_record.__dict__["key2"] == "value2"
-
-
-@pytest.mark.parametrize(
-    "args,extra,expected",
-    [
-        (
-            ("pii",),
-            {"foo": "bar", "tin": "123456789", "dashed-ssn": "123-45-6789"},
-            {
-                "msg": "pii",
-                "foo": "bar",
-                "tin": "*********",
-                "dashed-ssn": "*********",
-            },
-        ),
-        (
-            ("%s %s", "text", "123456789"),
-            None,
-            {
-                "msg": "%s %s",
-                "message": "text *********",
-            },
-        ),
-    ],
-)
-def test_mask_pii(init_test_logger, caplog: pytest.LogCaptureFixture, args, extra, expected):
-    logger = logging.getLogger(__name__)
-
-    logger.info(*args, extra=extra)
-
-    assert len(caplog.records) == 1
-    assert_dict_contains(caplog.records[0].__dict__, expected)

--- a/app/tests/src/logging/test_pii.py
+++ b/app/tests/src/logging/test_pii.py
@@ -1,4 +1,5 @@
 import pytest
+
 import src.logging.pii as pii
 
 
@@ -23,5 +24,5 @@ import src.logging.pii as pii
         ({"a": "x", "b": "999000000"}, "{'a': 'x', 'b': '*********'}"),
     ],
 )
-def test_mask_pii_private_function(input, expected):
+def test_mask_pii(input, expected):
     assert pii._mask_pii(input) == expected

--- a/app/tests/src/logging/test_pii.py
+++ b/app/tests/src/logging/test_pii.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 import src.logging.pii as pii
 
 
@@ -26,37 +25,3 @@ import src.logging.pii as pii
 )
 def test_mask_pii_private_function(input, expected):
     assert pii._mask_pii(input) == expected
-
-
-@pytest.mark.parametrize(
-    "args,extra,expected",
-    [
-        (
-            ("pii",),
-            {"foo": "bar", "tin": "123456789", "dashed-ssn": "123-45-6789"},
-            {
-                "msg": "pii",
-                "foo": "bar",
-                "tin": "*********",
-                "dashed-ssn": "*********",
-            },
-        ),
-        (
-            ("%s %s", "text", "123456789"),
-            None,
-            {
-                "msg": "%s %s",
-                "message": "text *********",
-            },
-        ),
-    ],
-)
-def test_mask_pii_in_log_record(
-    init_test_logger, caplog: pytest.LogCaptureFixture, args, extra, expected
-):
-    logger = logging.getLogger(__name__)
-
-    logger.info(*args, extra=extra)
-
-    assert len(caplog.records) == 1
-    assert_dict_contains(caplog.records[0].__dict__, expected)


### PR DESCRIPTION
## Ticket

Resolves #154 

## Changes
* Mask PII interpolation args separate from extra

## Context
Previously, something like `logger.info("%s %s", "text", "123456789")` would cause a logger error
since the mask_pii logic would replace the LogRecord's `args` tuple with the string '("text", "*********")',
which would break the log interpolation logic. This PR fixes that bug and adds some regression tests.

## Testing
Added tests that failed before the fix and pass after the fix