### PR TITLE
removed line to copy non-existant bin folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ git clone --single-branch --branch main --depth 1 git@github.com:navapbc/templat
 
 cp -r \
   template-application-flask/.github \
-  template-application-flask/bin \
   template-application-flask/docs \
   template-application-flask/app \
   template-application-flask/docker-compose.yml \


### PR DESCRIPTION
## Ticket
Issue #164 

## Changes
> Removed command to copy nonexistent bin folder from installation instructions in the readme. 

## Context for reviewers
> Follow installation instructions by copying and pasting commands into a new folder and ensure the error: `cp: template-application-flask/bin: No such file or directory` no longer appears.

## Testing
With error: 
![Screenshot 2023-05-25 at 10 29 58 AM](https://github.com/navapbc/template-application-flask/assets/25465464/e4f6dd48-d26c-4dce-8b3d-7f7a0729bba9)

Without error:
![Screenshot 2023-05-25 at 10 30 46 AM](https://github.com/navapbc/template-application-flask/assets/25465464/d33a7f9b-9c92-4963-b107-ef3d83103567)

