### PR TITLE
Update database management documentation

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -122,7 +122,7 @@ start-db:
 	docker-compose up --detach main-db
 
 ## Destroy current DB, setup new one
-db-recreate: clean-docker-volumes init-db
+db-recreate: clean-volumes init-db
 
 #########################
 # DB Migrations

--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -38,7 +38,7 @@ root
 ## Information
 
 * [API Technical Overview](./technical-overview.md)
-* [Database Migrations](./database/database-migrations.md)
+* [Database Management](./database/database-management.md)
 * [Formatting and Linting](./formatting-and-linting.md)
 * [Writing Tests](./writing-tests.md)
 

--- a/docs/app/database/database-management.md
+++ b/docs/app/database/database-management.md
@@ -11,8 +11,9 @@
 ## Basic operations
 ### Initialize
 
-To start a local Postgres database container in a detached state and run any 
-pending migrations, run `make init-db`. Running `make init` will also call `init-db` automatically.
+To start a local Postgres database container in a detached state and run any
+pending migrations, run `make init-db`. During initial setup, `init-db` is called
+automatically when running `make init`.
 
 ### Start
 
@@ -31,7 +32,9 @@ To clean the database, use the following command:
 make db-recreate
 ```
 
-This will remove _all_ docker project volumes, rebuild the database volume, and run all pending migrations. Once completed, only the database container will be running. Simply run `make start` to bring up all other project containers.
+This will remove _all_ docker project volumes, rebuild the database volume, and 
+run all pending migrations. Once completed, only the database container will be 
+running. Simply run `make start` to bring up all other project containers.
 
 ## Running migrations
 

--- a/docs/app/database/database-management.md
+++ b/docs/app/database/database-management.md
@@ -1,11 +1,43 @@
-# Database Migrations
+# Database Management
 
+- [Basic operations](#basic-operations)
+  - [Initialize](#initialize)
+  - [Start](#start)
+  - [Destroy and reinitialize](#destroy-and-reinitialize)
 - [Running migrations](#running-migrations)
 - [Creating new migrations](#creating-new-migrations)
 - [Multi-head situations](#multi-head-situations)
 - [Deployment](#deployment)
   - [Removing a column](#removing-a-column)
   - [Removing a table](#removing-a-table)
+
+## Basic operations
+### Initialize
+
+When setting up the environment, `make init` will take care of building the database and running a few basic migrations. Should there be a situation where this process needs to be repeated or ran separately, the following command will accomplish this:
+
+```sh
+make init-db
+```
+
+### Start
+
+To only start the database container, run the following command:
+
+```sh
+make start-db
+```
+This command is not needed when starting the application with `make start`
+
+### Destroy and reinitialize
+
+To clean the database, use the following command:
+
+```sh
+make db-recreate
+```
+
+This will remove _all_ docker project volumes, rebuild the database volume, and run all pending migrations. Once completed, only the database container will be running. Simply run `make start` to bring up all other project containers.
 
 ## Running migrations
 

--- a/docs/app/database/database-management.md
+++ b/docs/app/database/database-management.md
@@ -11,11 +11,8 @@
 ## Basic operations
 ### Initialize
 
-When setting up the environment, `make init` will take care of building the database and running a few basic migrations. Should there be a situation where this process needs to be repeated or ran separately, the following command will accomplish this:
-
-```sh
-make init-db
-```
+To start a local Postgres database container in a detached state and run any 
+pending migrations, run `make init-db`. Running `make init` will also call `init-db` automatically.
 
 ### Start
 

--- a/docs/app/database/database-management.md
+++ b/docs/app/database/database-management.md
@@ -7,9 +7,6 @@
 - [Running migrations](#running-migrations)
 - [Creating new migrations](#creating-new-migrations)
 - [Multi-head situations](#multi-head-situations)
-- [Deployment](#deployment)
-  - [Removing a column](#removing-a-column)
-  - [Removing a table](#removing-a-table)
 
 ## Basic operations
 ### Initialize


### PR DESCRIPTION
## Ticket
Resolves [#47](https://github.com/navapbc/template-application-flask/issues/47)

## Changes
- Renamed the database-migrations doc to `database-management`
- Added documentation for starting, stopping, and cleaning the database
- Removed unused deployment links in database-management document
- Updated `db-recreate` command in Makefile to call `clean-volumes` instead of `clean-docker-volumes`

## Context for reviewers
Some database documentation was missing. I believe it makes more sense to add it to the database-migrations document and rename to database-management.

## Testing
N/A

