### PR TITLE
Add basic index route

### DIFF
--- a/app/openapi.generated.yml
+++ b/app/openapi.generated.yml
@@ -10,33 +10,6 @@ tags:
 - name: Health
 - name: User
 paths:
-  /:
-    get:
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data: {}
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  warnings:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ValidationError'
-          description: Successful response
-      summary: Index
   /health:
     get:
       parameters: []

--- a/app/openapi.generated.yml
+++ b/app/openapi.generated.yml
@@ -10,6 +10,33 @@ tags:
 - name: Health
 - name: User
 paths:
+  /:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: The message to return
+                  data: {}
+                  status_code:
+                    type: integer
+                    description: The HTTP status code
+                  warnings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ValidationError'
+          description: Successful response
+      summary: Index
   /health:
     get:
       parameters: []

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -29,7 +29,7 @@ def create_app() -> APIFlask:
 
     configure_app(app)
     register_blueprints(app)
-    build_index_route(app)
+    register_index(app)
 
     return app
 
@@ -77,7 +77,7 @@ def get_project_root_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "..")
 
 
-def build_index_route(app: APIFlask) -> None:
+def register_index(app: APIFlask) -> None:
     @app.route("/")
     def index():
         return '''

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -81,7 +81,7 @@ def register_index(app: APIFlask) -> None:
     # When OpenAPI generates a definition for this route, it incorrectly
     # labels the response content type as application/json.
     @app.route("/")
-    def index():
+    def index() -> str:
         return '''
             <!Doctype html>
             <html>

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -82,7 +82,7 @@ def register_index(app: APIFlask) -> None:
     # labels the response content type as application/json.
     @app.route("/")
     def index() -> str:
-        return '''
+        return """
             <!Doctype html>
             <html>
                 <head><title>Home</title></head>
@@ -91,4 +91,4 @@ def register_index(app: APIFlask) -> None:
                     <p>Visit <a href="/docs">/docs</a> to view the api documentation for this project.</p>
                 </body>
             </html>
-        '''
+        """

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -29,6 +29,8 @@ def create_app() -> APIFlask:
 
     configure_app(app)
     register_blueprints(app)
+    build_index_route(app)
+
     return app
 
 
@@ -73,3 +75,18 @@ def register_blueprints(app: APIFlask) -> None:
 
 def get_project_root_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "..")
+
+
+def build_index_route(app: APIFlask) -> None:
+    @app.route("/")
+    def index():
+        return '''
+            <!Doctype html>
+            <html>
+                <head><title>Home</title></head>
+                <body>
+                    <h1>Home</h1>
+                    <p>Visit <a href="/docs">/docs</a> to view the api documentation for this project.</p>
+                </body>
+            </html>
+        '''

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -78,9 +78,8 @@ def get_project_root_dir() -> str:
 
 
 def register_index(app: APIFlask) -> None:
-    # When OpenAPI generates a definition for this route, it incorrectly
-    # labels the response content type as application/json.
     @app.route("/")
+    @app.doc(hide=True)
     def index() -> str:
         return """
             <!Doctype html>

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -78,6 +78,8 @@ def get_project_root_dir() -> str:
 
 
 def register_index(app: APIFlask) -> None:
+    # When OpenAPI generates a definition for this route, it incorrectly
+    # labels the response content type as application/json.
     @app.route("/")
     def index():
         return '''

--- a/app/tests/src/route/test_index_route.py
+++ b/app/tests/src/route/test_index_route.py
@@ -1,3 +1,4 @@
 def test_get_index_200(client):
     response = client.get("/")
     assert response.status_code == 200
+    assert "<h1>Home</h1>" in response.text

--- a/app/tests/src/route/test_index_route.py
+++ b/app/tests/src/route/test_index_route.py
@@ -1,0 +1,3 @@
+def test_get_index_200(client):
+    response = client.get("/")
+    assert response.status_code == 200


### PR DESCRIPTION
## Ticket

Resolves [#177](https://github.com/navapbc/template-application-flask/issues/177)

## Changes
Added and index route with basic html including a link to the swagger docs endpoint

## Context for reviewers
Previously the index route returned a 404 causing issues with e2e tests.

## Testing
Added `app/tests/src/route/test_index_route.py`

## Screenshots
![Screenshot 2023-06-22 at 1 48 43 PM](https://github.com/navapbc/template-application-flask/assets/3190079/1d39ecd5-0279-4078-b639-7007b86bfd0a)


