### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/app/getting-started.md
+++ b/docs/app/getting-started.md
@@ -23,17 +23,11 @@ A very simple [docker-compose.yml](/docker-compose.yml) has been included to sup
 
 4. You'll also need [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
-## Setup
-
-```bash
-make setup-local
-```
-
 ## Run the application
 
 1. In your terminal, `cd` to the `app` directory of this repo.
 2. Make sure you have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed & running.
-3. Run `make setup-local` to copy over `.env.example` to `.env`
+3. Run `make setup-local` to install dependencies
 4. Run `make init start` to build the image and start the container.
 5. Navigate to `localhost:8080/docs` to access the Swagger UI.
 6. Run `make run-logs` to see the logs of the running API container


### PR DESCRIPTION
## Ticket

N/A

## Changes
1. Looks like convention now is to use `local.env` and the description of `make setup-local` was outdated
2. remove "Setup" step because that's handled in the running the app steps

## Context
I just ran through the entire setup fresh and this reflects my experience.