### PR TITLE
Increase Postgres connection timeout to 10 seconds

### DIFF
--- a/app/src/adapters/db/clients/postgres_client.py
+++ b/app/src/adapters/db/clients/postgres_client.py
@@ -37,7 +37,7 @@ class PostgresDBClient(DBClient):
         def get_conn() -> Any:
             return psycopg2.connect(**get_connection_parameters(db_config))
 
-        conn_pool = pool.QueuePool(get_conn, max_overflow=10, pool_size=20, timeout=3)
+        conn_pool = pool.QueuePool(get_conn, max_overflow=10, pool_size=20)
 
         # The URL only needs to specify the dialect, since the connection pool
         # handles the actual connections.
@@ -98,7 +98,7 @@ def get_connection_parameters(db_config: PostgresDBConfig) -> dict[str, Any]:
         password=password,
         port=db_config.port,
         options=f"-c search_path={db_config.db_schema}",
-        connect_timeout=3,
+        connect_timeout=10,
         sslmode=db_config.ssl_mode,
         **connect_args,
     )

--- a/app/tests/src/adapters/db/clients/test_postgres_client.py
+++ b/app/tests/src/adapters/db/clients/test_postgres_client.py
@@ -50,6 +50,6 @@ def test_get_connection_parameters(monkeypatch: pytest.MonkeyPatch):
         password=db_config.password,
         port=db_config.port,
         options=f"-c search_path={db_config.db_schema}",
-        connect_timeout=3,
+        connect_timeout=10,
         sslmode="require",
     )


### PR DESCRIPTION
## Ticket



## Changes
- Increase Postgres connection timeout to 10 seconds
- Remove QueuePool timeout

## Context
Database migrations are occasionally timing out in the platform-test-flask repo.
Tuning this up to 10 seconds to see if that helps.
Also removing the QueuePool timeout which doesn't seem needed.

Example failing migration run:
https://github.com/navapbc/platform-test-flask/actions/runs/5798505305

database migration logs that show timeout expired
<img width="1611" alt="image" src="https://github.com/navapbc/template-application-flask/assets/447859/f9166895-eaa9-412e-889f-4f1dab88c91e">


See 🔒 [slack thread](https://nava.slack.com/archives/C03G1SWD9H7/p1690906746658009)

## Testing

relying on CI since small change