### PR TITLE
Use common prefix for db-migrate commands

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -116,7 +116,7 @@ check: format-check lint test
 # Docker starts the image for the DB but it's not quite
 # fully ready, so add a 5 second sleep so upgrade doesn't
 # fail because the DB hasn't started yet.
-init-db: start-db sleep-5 db-upgrade
+init-db: start-db sleep-5 db-migrate
 
 start-db:
 	docker-compose up --detach main-db
@@ -131,13 +131,13 @@ db-recreate: clean-volumes init-db
 alembic_config := ./src/db/migrations/alembic.ini
 alembic_cmd := $(PY_RUN_CMD) alembic --config $(alembic_config)
 
-db-upgrade: ## Apply pending migrations to db
+db-migrate: ## Apply pending migrations to db
 	$(PY_RUN_CMD) db-migrate
 
-db-downgrade: ## Rollback last migration in db
+db-migrate-down: ## Rollback last migration in db
 	$(PY_RUN_CMD) db-migrate-down
 
-db-downgrade-all: ## Rollback all migrations
+db-migrate-down-all: ## Rollback all migrations
 	$(PY_RUN_CMD) db-migrate-down-all
 
 check-migrate-msg:

--- a/docs/app/database/database-management.md
+++ b/docs/app/database/database-management.md
@@ -1,12 +1,13 @@
 # Database Management
 
-- [Basic operations](#basic-operations)
-  - [Initialize](#initialize)
-  - [Start](#start)
-  - [Destroy and reinitialize](#destroy-and-reinitialize)
-- [Running migrations](#running-migrations)
-- [Creating new migrations](#creating-new-migrations)
-- [Multi-head situations](#multi-head-situations)
+- [Database Management](#database-management)
+  - [Basic operations](#basic-operations)
+    - [Initialize](#initialize)
+    - [Start](#start)
+    - [Destroy and reinitialize](#destroy-and-reinitialize)
+  - [Running migrations](#running-migrations)
+  - [Creating new migrations](#creating-new-migrations)
+  - [Multi-head situations](#multi-head-situations)
 
 ## Basic operations
 ### Initialize
@@ -43,9 +44,9 @@ against your db so it has all the required tables. `make init` does this, but if
 needing to work with the migrations directly, some common commands:
 
 ```sh
-make db-upgrade       # Apply pending migrations to db
-make db-downgrade     # Rollback last migration to db
-make db-downgrade-all # Rollback all migrations
+make db-migrate       # Apply pending migrations to db
+make db-migrate-down     # Rollback last migration to db
+make db-migrate-down-all # Rollback all migrations
 ```
 
 ## Creating new migrations
@@ -54,7 +55,7 @@ If you've changed a python object model, auto-generate a migration file for the 
 
 ```sh
 $ make db-migrate-create MIGRATE_MSG="<brief description of change>"
-$ make db-upgrade
+$ make db-migrate
 ```
 
 <details>


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context

It's a worse developer experience that three of the commands related to database migrations don't follow the same prefix as all the rest, makes it impossible to tab-complete and harder to remember. This change renames db-upgrade, db-downgrade, and db-downgrade-all to db-migrate, db-migrade-down, and db-migrate-down-all.

## Testing

ran `make db-migrate`, `make db-migrate-down`, and `make db-migrate-down-all`