### PR TITLE
Remove Template from CI name

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -6,11 +6,11 @@ on:
       - main
     paths:
       - app/**
-      - .github/workflows/api-checks.yml
+      - .github/workflows/ci-app.yml
   pull_request:
     paths:
       - app/**
-      - .github/workflows/api-checks.yml
+      - .github/workflows/ci-app.yml
 
 defaults:
   run:

--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -1,4 +1,4 @@
-name: Template API Checks
+name: CI - App
 
 on:
   push:
@@ -39,4 +39,3 @@ jobs:
         run: |
           make test-audit
           make test-coverage
-        


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Remove the word "Template" from the CI name since this is the actual CI that will run on a project.
Also, Flask template doesn't require that the application is an API, so rename to "app".
Make it consistent with [Nextjs template CI name](https://github.com/navapbc/template-application-nextjs/blob/main/.github/workflows/ci-app.yml#L1)

## Testing

n/a