### PR TITLE
Fix verify_in_ssl log statement which no longer has access to SSL params

### DIFF
--- a/app/src/adapters/db/clients/postgres_client.py
+++ b/app/src/adapters/db/clients/postgres_client.py
@@ -121,12 +121,6 @@ def generate_iam_auth_token(aws_region: str, host: str, port: int, user: str) ->
 def verify_ssl(connection_info: Any) -> None:
     """Verify that the database connection is encrypted and log a warning if not."""
     if connection_info.pgconn.ssl_in_use:
-        logger.info(
-            "database connection is using SSL: %s",
-            ", ".join(
-                name + " " + connection_info.ssl_attribute(name)
-                for name in connection_info.ssl_attribute_names
-            ),
-        )
+        logger.info("database connection is using SSL")
     else:
         logger.warning("database connection is not using SSL")

--- a/app/tests/src/adapters/db/clients/test_postgres_client.py
+++ b/app/tests/src/adapters/db/clients/test_postgres_client.py
@@ -13,31 +13,24 @@ class DummyPgConn:
 
 
 class DummyConnectionInfo:
-    def __init__(self, ssl_in_use, attributes):
-        self.attributes = attributes
-        self.ssl_attribute_names = tuple(attributes.keys())
+    def __init__(self, ssl_in_use):
         self.pgconn = DummyPgConn(ssl_in_use)
-
-    def ssl_attribute(self, name):
-        return self.attributes[name]
 
 
 def test_verify_ssl(caplog):
     caplog.set_level(logging.INFO)  # noqa: B1
 
-    conn_info = DummyConnectionInfo(True, {"protocol": "ABCv3", "key_bits": "64", "cipher": "XYZ"})
+    conn_info = DummyConnectionInfo(True)
     verify_ssl(conn_info)
 
-    assert caplog.messages == [
-        "database connection is using SSL: protocol ABCv3, key_bits 64, cipher XYZ"
-    ]
+    assert caplog.messages == ["database connection is using SSL"]
     assert caplog.records[0].levelname == "INFO"
 
 
 def test_verify_ssl_not_in_use(caplog):
     caplog.set_level(logging.INFO)  # noqa: B1
 
-    conn_info = DummyConnectionInfo(False, {})
+    conn_info = DummyConnectionInfo(False)
     verify_ssl(conn_info)
 
     assert caplog.messages == ["database connection is not using SSL"]


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-application-flask/issues/200

## Changes

Removes log statement that relies on variables no longer in psycopg 3.

## Context for reviewers
The upgrade to psycopg3 got this error during migrations: `AttributeError: 'ConnectionInfo' object has no attribute 'ssl_attribute_names'` - https://github.com/navapbc/platform-test-flask/actions/runs/6275581568/job/17043454952

These aren't available anymore and looking through the connection info object, I don't see any equivalent. Looking at the docs for version 2, these attributes say `Only available if psycopg was built with libpq >= 9.5` https://www.psycopg.org/docs/extensions.html#psycopg2.extensions.ConnectionInfo.ssl_attribute 

While the docs for psycopg3 mention libpq as being the backing library it uses, I don't see any mention of these parameters in their docs. https://www.psycopg.org/psycopg3/docs/api/connections.html#psycopg.Connection.pgconn - so seems to just be gone entirely?

## Testing
Updated tests