### PR TITLE
Update Dockle ignore to have new Python version in path

### DIFF
--- a/.dockleconfig
+++ b/.dockleconfig
@@ -5,4 +5,4 @@
 # DOCKLE_ACCEPT_FILES="file1,path/to/file2,file3/path,etc"
 
 # The apiflask/settings file is a stub file that apiflask creates, and has no sensitive data in. We are ignoring it since it is unused
-DOCKLE_ACCEPT_FILES=app/.venv/lib/python3.11/site-packages/apiflask/settings.py
+DOCKLE_ACCEPT_FILES=app/.venv/lib/python3.12/site-packages/apiflask/settings.py


### PR DESCRIPTION


## Changes

Update the Dockle config to ignore the Python 3.12 path for APIFlask settings file

## Context for reviewers

https://github.com/navapbc/platform-test-flask/actions/runs/6474165939/job/17578510105

## Testing

I'm not sure how to get Dockle to run locally (not sure how to specify our image?), but this is fairly minor.
