### PR TITLE
Ignore Poetry installation error log files.

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -26,3 +26,6 @@ coverage.*
 # VSCode Workspace
 *.code-workspace
 .vscode
+
+# Poetry installer local error logs
+poetry-installer-error-*.log


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Add a line to the gitignore file for app to ignore local Poetry error log files. 

## Context for reviewers

These are only relevant to the individual's local dev env and do not belong in the repo.

## Testing

Tested by running git status and seeing that my many local Poetry installation error log files are now ignored. 😀

Before:
<img width="606" alt="image" src="https://github.com/navapbc/template-application-flask/assets/5387486/bfbb46d8-b495-4268-95c4-b3e00d3269b5">

After:
<img width="532" alt="image" src="https://github.com/navapbc/template-application-flask/assets/5387486/63b13012-ef3a-41ba-91da-d87b0fbe79bb">

