### PR TITLE
Fix buggy md syntax in technical-overview.md

### DIFF
--- a/docs/app/technical-overview.md
+++ b/docs/app/technical-overview.md
@@ -19,7 +19,7 @@ generally preferred.
 - [OpenAPI Specification][oas-docs]
 - [API Flask][apiflask-home] ([source code][apiflask-src])
 - [SQLAlchemy][sqlalchemy-home] ([source code][sqlalchemy-src])
-- [Alembic][alembic-home] ([source code](alembic-src))
+- [Alembic][alembic-home] ([source code][alembic-src])
 - [pydantic][pydantic-home] ([source code][pydantic-src])
 - [poetry](https://python-poetry.org/docs/) - Python dependency management
 


### PR DESCRIPTION
## Ticket

Resolves linter complaint:
```
  ERROR: 1 dead links found!
  [✖] alembic-src → Status: 400
```

## Changes

Use square brackets, not parentheses.

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

## Testing

The markdown linter should not cause this error.