### PR TITLE
Bump Postgres to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   main-db:
-    image: postgres:14-alpine
+    image: postgres:16-alpine
     container_name: main-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     environment:


### PR DESCRIPTION
## Ticket

Resolves #218 

## Changes

Change Docker image used for local development to Postgres 16.

## Context for reviewers
Sibling PR for [bump to 16.2 in the infra template](https://github.com/navapbc/template-infra/pull/627).

## Testing
All existing tests pass.
