### PR TITLE
Remove version from docker compose files

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,8 +1,5 @@
-version: "3.8"
-
 # run with `docker compose -f`
 # combines ports and env vars with the main docker-compose.yml main-app service
-
 services:
   main-app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   main-db:


### PR DESCRIPTION
## Ticket
n/a

## Changes

Removed version from the docker-compose files

## Context for reviewers

As of a recent version of docker, the version included at the top of a compose file is no longer needed and causes a warning whenever you run a command.

https://docs.docker.com/compose/compose-file/04-version-and-name/

## Testing
Before this change, running make commands gave this warning message:
![Screenshot 2024-06-20 at 10 51 26 AM](https://github.com/navapbc/template-application-flask/assets/46358556/9f49d86a-28e9-4120-b1bd-9218e3f68403)

After:
![Screenshot 2024-06-20 at 10 55 51 AM](https://github.com/navapbc/template-application-flask/assets/46358556/e403c059-20b8-4700-8d64-5384cbf433f3)

