### PR TITLE
Fix links to docker-compose.yml

### DIFF
--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -96,9 +96,9 @@ direnv: export +API_AUTH_TOKEN +AWS_ACCESS_KEY_ID +AWS_DEFAULT_REGION +AWS_SECRE
 
 Most configuration options are managed by environment variables.
 
-Environment variables for local development are stored in the [local.env](/app/local.env) file. This file is automatically loaded when running. If running within Docker, this file is specified as an `env_file` in the [docker-compose](/docker-compose.yml) file, and loaded [by a script](/app/src/util/local.py) automatically when running unit tests (see running natively above for other cases).
+Environment variables for local development are stored in the [local.env](/app/local.env) file. This file is automatically loaded when running. If running within Docker, this file is specified as an `env_file` in the [docker-compose](/app/docker-compose.yml) file, and loaded [by a script](/app/src/util/local.py) automatically when running unit tests (see running natively above for other cases).
 
-Any environment variables specified directly in the [docker-compose](/docker-compose.yml) file will take precedent over those specified in the [local.env](/app/local.env) file.
+Any environment variables specified directly in the [docker-compose](/app/docker-compose.yml) file will take precedent over those specified in the [local.env](/app/local.env) file.
 
 ## Authentication
 

--- a/docs/app/getting-started.md
+++ b/docs/app/getting-started.md
@@ -2,7 +2,7 @@
 
 This application is dockerized. Take a look at [Dockerfile](/app/Dockerfile) to see how it works.
 
-A very simple [docker-compose.yml](/docker-compose.yml) has been included to support local development and deployment. Take a look at [docker-compose.yml](/docker-compose.yml) for more information.
+A very simple [docker-compose.yml](/app/docker-compose.yml) has been included to support local development and deployment. Take a look at [docker-compose.yml](/app/docker-compose.yml) for more information.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - #227 moved the docker-compose.yml file out of the root and into /app, but missed updating links to it in the documentation. This updates those links.

## Context for reviewers
n/a

## Testing
n/a