### PR TITLE
Fix writing-tests.md reference to enable_factory_create

### DIFF
--- a/docs/app/writing-tests.md
+++ b/docs/app/writing-tests.md
@@ -81,7 +81,7 @@ factories](https://factoryboy.readthedocs.io/en/stable/#using-factories), termed
 The build strategy is useful if the code under test just needs the data on the
 model and doesn't actually perform any database interactions.
 
-In order to use the create strategy, pull in the `initialize_factories_session`
+In order to use the create strategy, pull in the `enable_factory_create`
 fixture.
 
 Regardless of the strategy, you can override the values for attributes on the


### PR DESCRIPTION
## Ticket

Small documentation correction to be consistent with code.

## Changes

https://github.com/navapbc/template-application-flask/blob/dded29ce1ae0d3b9cd067a971850a290da29e0c2/docs/app/writing-tests.md?plain=1#L84 
refers to `initialize_factories_session` but should be `enable_factory_create`

## Testing

Compare with https://github.com/navapbc/template-application-flask/blob/dded29ce1ae0d3b9cd067a971850a290da29e0c2/docs/app/database/database-testing.md?plain=1#L13
and https://github.com/navapbc/template-application-flask/blob/dded29ce1ae0d3b9cd067a971850a290da29e0c2/app/tests/conftest.py#L98-L105
