### PR TITLE
Pin Python minor version and document upgrade details

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,9 @@
 # The build stage that will be used to deploy to the various environments
 # needs to be called `release` in order to integrate with the repo's
 # top-level Makefile
-FROM python:3-slim AS base
+FROM python:3.12-slim AS base
+# See /docs/app/README.md#Upgrading Python
+# for details on upgrading your Python version
 
 # Install poetry, the package manager.
 # https://python-poetry.org

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -949,7 +949,7 @@ files = [
 
 [package.dependencies]
 marshmallow = [
-    {version = ">=3.13.0,<4.0", optional = true, markers = "python_version < \"3.7\" or extra != \"enum\""},
+    {version = ">=3.13.0,<4.0"},
     {version = ">=3.18.0,<4.0", optional = true, markers = "python_version >= \"3.7\" and extra == \"enum\""},
 ]
 typeguard = {version = ">=2.4.1,<4.0.0", optional = true, markers = "extra == \"union\""}
@@ -1981,5 +1981,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "259e2bd37870236ef86dc5893950acf19912b7468e906dc61f78436ea5f34796"
+python-versions = "~3.12"
+content-hash = "885d91299426a19ef533e20f8d85a652c639eb031091bbb9501da467c374e873"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -6,7 +6,9 @@ packages = [{ include = "src" }]
 authors = ["Nava Engineering <engineering@navapbc.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+# See /docs/app/README.md#Upgrading Python
+# for details on upgrading your Python version
+python = "~3.12"
 SQLAlchemy = {version = "^2.0.21", extras = ["mypy"]}
 alembic = "^1.12.0"
 python-dotenv = "^1.0.0"

--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -153,59 +153,29 @@ The API can be run in debug mode that allows for remote attach debugging (curren
 }
 ```
 
-# Upgrading Python
+## Upgrading Python
 Python does [yearly releases](https://devguide.python.org/versions/) for their minor versions (eg. 3.12 -> 3.13). They do not
 use semvar versioning, and their [minor releases](https://devguide.python.org/developer-workflow/development-cycle/#devcycle) contain
 breaking changes.
 
-We have this environment configured to use a specific minor version of python just in case anything would break when the yearly release does occur.
+Pin to a specific minor version of python just in case anything would break when the yearly release does occur.
+Only pin the minor versions of Python (eg. 3.12), and not the patch versions (eg. 3.12.1) as those contain bug and security fixes.
 
-We recommend as a starting point, only pin the minor versions of Python (eg. 3.12), and not the patch versions (eg. 3.12.1) as those contain bug and security fixes.
-However, your project may have dependencies, or tools that rely on very specific patch versions of Python, so adjust your approach as necessary.
+Along with any version upgrades, remember to:
+- Test the system functionality before deploying to production
+- Review the [changelog](https://docs.python.org/3/whatsnew/changelog.html)
+for any breaking changes of features you may use
 
-Along with any version upgrades, you should follow all best practices for upgrading software and test the functionality
-of your system before deploying to production. It is also recommended to review the [changelog](https://docs.python.org/3/whatsnew/changelog.html)
-for any breaking changes of features you may use.
-
-## Local Development
-If you run any of the python code outside of the Docker container, first upgrade your version
-of Python locally. The exact way you upgrade will depend on how you originally installed Python,
-but one strongly recommended approach is to use [pyenv](https://github.com/pyenv/pyenv) which allows
-you to install and swap between different python versions locally.
-
-If you run commands with Poetry, you'll also need to [configure](https://python-poetry.org/docs/managing-environments/#switching-between-environments)
-it to use the approach python version.
-
-## Dockerfile
-The dockerfile that our API is built from specifies the Python version as the first step.
-To upgrade this, simply change the version to the version you would like to use.
-
-For example, to upgrade from 3.12 to 3.13, change the following line:
-```dockerfile
-FROM python:3.12-slim AS base
-```
-to
-```dockerfile
-FROM python:3.13-slim AS base
-```
-
-## Poetry
-Adjust the pyproject.toml file line that specifies the version of Python used
-to your new version. For example, to upgrade from 3.12 to 3.13, change it from:
-
-```toml
-[tool.poetry.dependencies]
-python = "~3.12"
-```
-
-to
-```toml
-[tool.poetry.dependencies]
-python = "~3.13"
-```
-
-You will then need to run `poetry lock --no-update` to make the lock file reflect this change.
-
-## Misc
-Some tools, include pyenv, reference the [.python-version](/app/.python-version) file in order to determine which
-version of python should be used. Update this to the approach version as well.
+### Upgrade Steps
+To upgrade the Python version, make changes in the following places:
+1. Local Python version (see more about managing local Python versions in [getting started](/docs/app/getting-started.md))
+2. [Dockerfile](/app/Dockerfile)
+    search for the line `FROM python:3.12-slim as base` - supported versions can be found on [Dockerhub](https://hub.docker.com/_/python)
+3. [pyproject.toml](/app/pyproject.toml)
+    search for the line
+    ```toml
+    [tool.poetry.dependencies]
+    python = "~3.12"
+    ```
+   Then run `poetry lock --no-update` to update the [poetry.lock](/app/poetry.lock) file.
+4. [.python-version](/app/.python-version) which is used by tools like pyenv

--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -152,3 +152,60 @@ The API can be run in debug mode that allows for remote attach debugging (curren
     ]
 }
 ```
+
+# Upgrading Python
+Python does [yearly releases](https://devguide.python.org/versions/) for their minor versions (eg. 3.12 -> 3.13). They do not
+use semvar versioning, and their [minor releases](https://devguide.python.org/developer-workflow/development-cycle/#devcycle) contain
+breaking changes.
+
+We have this environment configured to use a specific minor version of python just in case anything would break when the yearly release does occur.
+
+We recommend as a starting point, only pin the minor versions of Python (eg. 3.12), and not the patch versions (eg. 3.12.1) as those contain bug and security fixes.
+However, your project may have dependencies, or tools that rely on very specific patch versions of Python, so adjust your approach as necessary.
+
+Along with any version upgrades, you should follow all best practices for upgrading software and test the functionality
+of your system before deploying to production. It is also recommended to review the [changelog](https://docs.python.org/3/whatsnew/changelog.html)
+for any breaking changes of features you may use.
+
+## Local Development
+If you run any of the python code outside of the Docker container, first upgrade your version
+of Python locally. The exact way you upgrade will depend on how you originally installed Python,
+but one strongly recommended approach is to use [pyenv](https://github.com/pyenv/pyenv) which allows
+you to install and swap between different python versions locally.
+
+If you run commands with Poetry, you'll also need to [configure](https://python-poetry.org/docs/managing-environments/#switching-between-environments)
+it to use the approach python version.
+
+## Dockerfile
+The dockerfile that our API is built from specifies the Python version as the first step.
+To upgrade this, simply change the version to the version you would like to use.
+
+For example, to upgrade from 3.12 to 3.13, change the following line:
+```dockerfile
+FROM python:3.12-slim AS base
+```
+to
+```dockerfile
+FROM python:3.13-slim AS base
+```
+
+## Poetry
+Adjust the pyproject.toml file line that specifies the version of Python used
+to your new version. For example, to upgrade from 3.12 to 3.13, change it from:
+
+```toml
+[tool.poetry.dependencies]
+python = "~3.12"
+```
+
+to
+```toml
+[tool.poetry.dependencies]
+python = "~3.13"
+```
+
+You will then need to run `poetry lock --no-update` to make the lock file reflect this change.
+
+## Misc
+Some tools, include pyenv, reference the [.python-version](/app/.python-version) file in order to determine which
+version of python should be used. Update this to the approach version as well.


### PR DESCRIPTION
## Changes

Pin the Python version and document details on how to upgrade

## Context for reviewers

Python releases new minor versions (3.12, 3.13, etc.) every year in October. It usually takes a few weeks for all of our dependencies and tooling to also be upgraded to the latest version, causing our builds to break. There isn't much we can do except wait a few weeks and then do the upgrade (assuming no breaking changes in features we use).

However, we had some of our dependencies pinned to the major version (Python 3) so it has broken the past few years until it started working again when the dependencies got fixed. This is just getting ahead of that and making sure the upgrade to Python 3.13 doesn't cause any problems.

## Testing
This change is largely documentation as the Python version used in the dockerfile + pyproject.toml already would have resolved to Python 3.12, this just makes it so it won't auto-upgrade to 3.13 when that releases in October.