### PR TITLE
Update docker-compose.yml.jinja

### DIFF
--- a/template/{{app_name}}/docker-compose.yml.jinja
+++ b/template/{{app_name}}/docker-compose.yml.jinja
@@ -20,14 +20,14 @@ services:
       args:
         - RUN_UID=${RUN_UID:-4000}
         - RUN_USER=${RUN_USER:-app}
-    command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "8080", "--reload"]
+    command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "{{ app_local_port }}", "--reload"]
     env_file:
       - path: ./local.env
         required: true
       - path: ./override.env
         required: false
     ports:
-      - 8080:{{ app_local_port }}
+      - {{ app_local_port }}:{{ app_local_port }}
     volumes:
       - ./:/app
     depends_on:


### PR DESCRIPTION
## Ticket

n/a

## Changes
Make the local container for development use the port specified in the platform-cli tool

## Context for reviewers


## Testing
Install the flask template using the CLI, use the default suggested port of 3000. The docs will update to say that you can access it after running `make init start` at localhost:3000, but you'll need to update the docker-compose as suggested in this PR first.