### PR TITLE
Update OpenAPI CI to use {{ app_name }} for working directory

### DIFF
--- a/template/.github/workflows/ci-{{app_name}}-openapi.yml.jinja
+++ b/template/.github/workflows/ci-{{app_name}}-openapi.yml.jinja
@@ -10,7 +10,7 @@ on:
 
 defaults:
   run:
-    working-directory: ./app
+    working-directory: ./{{app_name}}
 
 # Only trigger run one update of the OpenAPI spec at a time on the branch.
 # If new commits are pushed to the branch, cancel in progress runs and start


### PR DESCRIPTION
## Ticket

N/A

## Changes

Specify working directory for CI with {{ app_name }} rather than hardcoded `app`

## Testing

See CI failing here: https://github.com/navapbc/bid-fed-hhs-simpler-grants-management/actions/runs/16778176613/job/47509360573 when installed in a non-default directory (`api`), and then passing when updated to the app name here: https://github.com/navapbc/bid-fed-hhs-simpler-grants-management/actions/runs/16778901279/job/47511897649?pr=36
