### PR TITLE
Configure isort to follow black formatting conventions

### DIFF
--- a/template/{{app_name}}/pyproject.toml
+++ b/template/{{app_name}}/pyproject.toml
@@ -55,11 +55,6 @@ line-length = 100
 
 [tool.isort]
 profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 100
 
 [tool.ruff]
 line-length = 100

--- a/template/{{app_name}}/pyproject.toml
+++ b/template/{{app_name}}/pyproject.toml
@@ -54,6 +54,7 @@ db-migrate-down-all = "src.db.migrations.run:downall"
 line-length = 100
 
 [tool.isort]
+profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - Configure isort to follow black formatting conventions

## Context for reviewers
 - Without this change there are situations where isort's formatting conflicts with blacks, leading `make format-check` to fail even after `make-format`

## Testing
You can see an example file that will fail without this change at this PR: https://github.com/navapbc/labs-referral-pilot/pull/11